### PR TITLE
Add top-level fields to invariant webhook payload

### DIFF
--- a/executor_mod/invariants.py
+++ b/executor_mod/invariants.py
@@ -143,13 +143,25 @@ def _emit(st: Dict[str, Any], inv_id: str, severity: str, message: str, details:
     with suppress(Exception):
         log_event("INVARIANT_FAIL", invariant_id=inv_id, severity=severity, msg=message, **details)
 
+    prices = pos.get("prices") if isinstance(pos, dict) else None
     payload: Dict[str, Any] = {
         "event": "INVARIANT_FAIL",
+        "ts_s": nowv,
+        "pos_key": pkey,
         "mode": (pos.get("mode") if isinstance(pos, dict) else None) or "unknown",
         "symbol": ENV.get("SYMBOL"),
         "invariant_id": inv_id,
+        "inv_id": inv_id,
         "severity": severity,
         "message": message,
+        "side": pos.get("side") if isinstance(pos, dict) else None,
+        "status": pos.get("status") if isinstance(pos, dict) else None,
+        "qty": pos.get("qty") if isinstance(pos, dict) else None,
+        "entry": pos.get("entry") if isinstance(pos, dict) else None,
+        "trail_active": pos.get("trail_active") if isinstance(pos, dict) else None,
+        "sl": prices.get("sl") if isinstance(prices, dict) else None,
+        "tp1": prices.get("tp1") if isinstance(prices, dict) else None,
+        "tp2": prices.get("tp2") if isinstance(prices, dict) else None,
         "position": {
             "side": pos.get("side") if isinstance(pos, dict) else None,
             "status": pos.get("status") if isinstance(pos, dict) else None,


### PR DESCRIPTION
### Motivation
- Improve webhook readability by surfacing common position and metadata at the payload top level for easier consumption and debugging.
- Preserve existing behavior for throttling, persistence, and logging while adding non-breaking, safe-access fields.

### Description
- In `_emit` added `prices = pos.get("prices") if isinstance(pos, dict) else None` and extended the webhook `payload` with top-level keys `ts_s`, `pos_key`, and `inv_id` (duplicate of `invariant_id`).
- Added top-level position fields `side`, `status`, `qty`, `entry`, and `trail_active` using safe access when `pos` is a dict.
- Added top-level price targets `sl`, `tp1`, and `tp2` sourced from `prices` using safe access when `prices` is a dict.
- Kept the existing nested `position` and `details` fields and did not change throttle, persist, or logging logic.

### Testing
- No automated tests were executed as part of this change.
- The change is limited to data shaping for the outgoing webhook and contains only safe-access reads to avoid exceptions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695afebd4d608323bbb6c7d788d613b1)