### PR TITLE
Pass log_event to trail.configure

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -228,7 +228,7 @@ def read_tail_lines(path: str, n: int) -> List[str]:
 # Configure margin guard hooks (future margin support; safe no-op by default)
 with suppress(Exception):
     margin_guard.configure(ENV, log_event)
-trail.configure(ENV, read_tail_lines)
+trail.configure(ENV, read_tail_lines, log_event)
 
 def _now_s() -> float:
     return time.time()


### PR DESCRIPTION
### Motivation
- Ensure trailing confirmation events emitted by the trail helper are forwarded into the executor's existing logging pipeline via the `log_event` hook.
- Wire the `log_event` hook into the trail module so `executor_mod/trail.py` can record `TRAIL_CONFIRM_*` events through the executor logger.

### Description
- Update `executor.py` to call `trail.configure(ENV, read_tail_lines, log_event)` instead of the previous two-argument call to `trail.configure`.
- This one-line change complements the trail module update that added a `log_event` parameter and internal `_LOG_EVENT` wrapper in `executor_mod/trail.py`.
- No other behavioral changes, loops, timers, or ENV defaults were added.

### Testing
- No automated tests were run for this change.
- The change is a minimal one-line wiring update in `executor.py` and does not modify runtime logic beyond enabling event logging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bf67d9b38832386dd08c964f7c4e5)