### PR TITLE
Handle missing exit reconciliation alerts

### DIFF
--- a/test/test_wiring_recon_exit_missing.py
+++ b/test/test_wiring_recon_exit_missing.py
@@ -1,0 +1,13 @@
+import pathlib
+import unittest
+
+
+class TestWiringReconExitMissing(unittest.TestCase):
+    def test_executor_has_recon_exit_missing_event(self):
+        root = pathlib.Path(__file__).resolve().parents[1]
+        txt = (root / "executor.py").read_text(encoding="utf-8")
+        self.assertIn("RECON_EXIT_MISSING", txt)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Ensure the sync routine can detect and reconcile missing TP/SL exit orders for live positions when Binance reports that an order does not exist or returns -2013.
- Prevent reconciliation from failing when webhook delivery (n8n) is unreachable so alerts do not crash `sync_from_binance()`.

### Description
- Add logic in `sync_from_binance()` to build `open_ids` from tagged open orders and iterate `tp1`, `tp2`, `sl` to reconcile against current open orders and `binance_api.check_order_status()` as a fallback.
- Treat Binance errors containing `"order does not exist"`, `"unknown order"`, or `"-2013"` as `NOT_FOUND` and mark the order as missing for reconciliation.
- When an exit is found `FILLED` set `pos["tp1_done"]`/`pos["tp2_done"]` as appropriate, and when missing/ canceled/expired with zero executed quantity clear the order id, log `RECON_EXIT_MISSING`, send a webhook, and persist state via `save_state(st)`.
- Wrap `send_webhook(...)` in a `with suppress(Exception):` block to avoid reconciliation crashes if webhook delivery fails.

### Testing
- Added a wiring test `test/test_wiring_recon_exit_missing.py` that asserts `RECON_EXIT_MISSING` appears in `executor.py` and thus prevents regressions to the event name.
- No automated test suite was executed as part of this change; the wiring test was created but not run.
- Local verification shows the modified `sync_from_binance()` block and the new test file are present in the working tree.
- Manual inspection was used to validate the applied changes compiled into the module without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fa87d751c83239b5f5105d24326aa)