### PR TITLE
Reconcile missing/active exit orders, capture executedQty, and throttle alerts

### DIFF
--- a/executor_mod/binance_api.py
+++ b/executor_mod/binance_api.py
@@ -238,6 +238,10 @@ def check_order_status(symbol: str, order_id: int) -> Dict[str, Any]:
     return _binance_signed_request("GET", "/api/v3/order", {"symbol": symbol, "orderId": order_id})
 
 
+def get_order(symbol: str, order_id: int) -> Dict[str, Any]:
+    return check_order_status(symbol, order_id)
+
+
 def cancel_order(symbol: str, order_id: int) -> Dict[str, Any]:
     env = _env()
     mode = str(env.get("TRADE_MODE", "spot")).strip().lower()

--- a/test/test_recon_missing_alerts.py
+++ b/test/test_recon_missing_alerts.py
@@ -1,0 +1,15 @@
+import pathlib
+import unittest
+
+
+class TestReconMissingAlerts(unittest.TestCase):
+    def test_executor_recon_missing_wiring(self):
+        root = pathlib.Path(__file__).resolve().parents[1]
+        txt = (root / "executor.py").read_text(encoding="utf-8")
+        self.assertIn("RECON_ORDER_MISSING", txt)
+        self.assertIn("binance_api.get_order", txt)
+        self.assertNotIn("tp2_done = True", txt)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Improve visibility when tagged exit orders are missing from local state but either do not exist on Binance or are still active on exchange.  
- Avoid silent state drift by removing disappeared exit orders and recording recon metadata without performing auto-repair.  
- Prevent alert spam by adding per-position throttling for recon events.  
- Provide executed quantity visibility for active-but-untracked exits to aid operator decisions.

### Description
- Added per-position `recon` storage with `last_emit` throttling and a `RECON_THROTTLE_SEC` env entry, plus helper functions `_should_emit` and `_emit` to throttle and safely send alerts.  
- Use `binance_api.get_order` (thin wrapper around `check_order_status`) and capture `executedQty` when available.  
- Treat Binance "-2013" / "order does not exist" / "unknown order" errors as missing exits: remove the order from `pos["orders"]`, set `<key>_missing_ts`/`<key>_missing_reason`, and emit `RECON_ORDER_MISSING`.  
- Emit `RECON_ORDER_FILLED_SEEN`, `RECON_ORDER_UNKNOWN`, and a new `RECON_EXIT_NOT_IN_OPEN_BUT_ACTIVE` event (includes `executedQty`) for orders that are not in `open_orders` but still active on exchange, and persist state via `save_state(st)` when modified.

### Testing
- Added a unit test `test/test_recon_missing_alerts.py` that verifies presence of `RECON_ORDER_MISSING`, `binance_api.get_order`, and that `tp2_done = True` is not present.  
- No automated test suite was executed during this rollout; the new unit test was added but not run.  
- The recon alert path uses `with suppress(Exception)` around `send_webhook` to avoid test/production crashes when webhook delivery fails.  
- Basic commit verified locally (no CI run reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fb26d4d2483239ce421a7cf9bb6e4)