### PR TITLE
Keep invariant runtime metadata in memory and disable persistence by default

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -186,7 +186,7 @@ ENV: Dict[str, Any] = {
 "INVAR_GRACE_SEC": _get_int("INVAR_GRACE_SEC", 15),
 "INVAR_FEED_STALE_SEC": _get_int("INVAR_FEED_STALE_SEC", 180),
 "INVAR_KILL_ON_DEBT": _get_bool("INVAR_KILL_ON_DEBT", False),
-"INVAR_PERSIST": _get_bool("INVAR_PERSIST", True),
+"INVAR_PERSIST": _get_bool("INVAR_PERSIST", False),
 "I13_GRACE_SEC": _get_int("I13_GRACE_SEC", 300),
 "I13_ESCALATE_SEC": _get_int("I13_ESCALATE_SEC", 180),
 "I13_EXCHANGE_CHECK": _get_bool("I13_EXCHANGE_CHECK", True),

--- a/test/test_invariants_module.py
+++ b/test/test_invariants_module.py
@@ -212,9 +212,8 @@ class TestInvariantsModule(unittest.TestCase):
         self.inv._check_i8_state_shape_live_position(st)
         self.assertEqual(len(self.sent), 0)
 
-    def test_invar_persist_zero_does_not_save_state(self):
+    def test_invariants_do_not_save_state(self):
         # Should still emit webhook/log, but must NOT call save_state
-        self.inv.ENV["INVAR_PERSIST"] = "0"
         st = {
             "position": {
                 "mode": "live",
@@ -227,27 +226,8 @@ class TestInvariantsModule(unittest.TestCase):
         self.assertEqual(self._count("I8"), 1)
         self.assertEqual(len(self.saved), 0)
 
-    def test_prune_inv_throttle_removes_old_entries(self):
-        st = {
-            "position": {
-                "mode": "live",
-                "status": "OPEN",
-                "orders": None,
-                "prices": None,
-            },
-            "inv_throttle": {
-                "OLD": self.now - (8 * 24 * 3600),
-                "NEW": self.now - 10,
-            },
-        }
-        self.inv._check_i8_state_shape_live_position(st)
-        inv_th = st.get("inv_throttle", {})
-        self.assertIn("NEW", inv_th)
-        self.assertNotIn("OLD", inv_th)
-
     def test_i10_events_are_capped_to_100(self):
-        # Avoid spamming save_state in a loop
-        self.inv.ENV["INVAR_PERSIST"] = "0"
+        # Avoid spamming state writes in a loop
         st = {
             "position": {
                 "mode": "live",
@@ -263,7 +243,7 @@ class TestInvariantsModule(unittest.TestCase):
             self.inv._check_i10_repeated_trail_stop_errors(st)
 
         pkey = self.inv._pos_key(st["position"])
-        events = st["inv_runtime"]["I10"][pkey]["events"]
+        events = self.inv._inv_runtime_cache["I10"][pkey]["events"]
         self.assertLessEqual(len(events), 100)
 
 


### PR DESCRIPTION
### Motivation
- Avoid invariants writing runtime/throttle metadata into the executor state file to prevent spurious state updates and log/state churn.
- Keep invariant runtime counters and throttle data available in-process so detector logic still functions without persisting to disk.
- Make persistence explicit and opt-in via `INVAR_PERSIST` rather than relying on implicit state writes.

### Description
- Set `INVAR_PERSIST` default to `False` in `executor.py` so persistence is disabled unless explicitly enabled.
- Replace persisted runtime bucket with an in-process cache by adding `_inv_runtime_cache` and `_inv_runtime()` in `executor_mod/invariants.py` and remove `_persist_runtime()` and related persistence branches.
- Stop mutating `st["inv_runtime"]` and `st["inv_throttle"]` and remove `save_state` calls from invariant code paths; throttling now relies on process-local `_last_emit` and runtime on `_inv_runtime_cache`.
- Update tests in `test/test_invariants_module.py` to reflect in-memory runtime (rename test, remove persistence assertions, and read from `self.inv._inv_runtime_cache`).

### Testing
- No automated tests were executed during this change.
- Unit tests in `test/test_invariants_module.py` were updated to match the new in-memory runtime behavior but were not run here.
- The repository was lint/committed locally (files changed: `executor.py`, `executor_mod/invariants.py`, `test/test_invariants_module.py`).
- Manual runtime/behavioural validation is recommended, especially for long-running deployments and disk/daemon restart scenarios where in-memory state will not survive restarts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962c8ae0f988323afbad6c9ceda4152)