### PR TITLE
Persist I13 margin clear state and exchange-check meta on success

### DIFF
--- a/executor_mod/invariants.py
+++ b/executor_mod/invariants.py
@@ -1075,6 +1075,10 @@ def _check_i13_no_debt_after_close(st: Dict[str, Any]) -> None:
     rt["next_exchange_check_s"] = nowv + _i13_min_interval_sec()
     rt["last_exchange_has_debt"] = has_debt
     inv_runtime["I13"] = rt
+    # Persist exchange-check backoff even when no WARN/ERROR is emitted.
+    _meta_mark_dirty()
+    with suppress(Exception):
+        _meta_save(nowv)
 
     # Exchange says "clear" -> finish episode, optional local state clear
     if not has_debt:
@@ -1085,6 +1089,9 @@ def _check_i13_no_debt_after_close(st: Dict[str, Any]) -> None:
                     margin.pop("borrowed_assets", None)
                     margin.pop("borrowed_by_trade", None)
                 st["margin"] = margin
+                if save_state is not None:
+                    with suppress(Exception):
+                        save_state(st)
         inv_runtime.pop("I13", None)
         _meta_mark_dirty()
         with suppress(Exception):

--- a/test/test_invariants_margin.py
+++ b/test/test_invariants_margin.py
@@ -49,6 +49,9 @@ class TestInvariantsMargin(unittest.TestCase):
             "INVAR_THROTTLE_SEC": 0,
             "INVAR_GRACE_SEC": 10,
             "SYMBOL": "BTCUSDT",
+            "INVAR_STATE_FN": str(
+                Path(__file__).resolve().parent / f".tmp_invariants_state_{time.time_ns()}.json"
+            ),
         }
 
         cfg = self.inv.configure


### PR DESCRIPTION
### Motivation
- Ensure I13 invariant exchange-check backoff/timing survive restarts by persisting the invariant meta after a successful exchange snapshot even when no WARN/ERROR is emitted.
- Ensure that when the exchange reports no debt and `I13_CLEAR_STATE_ON_EXCHANGE_CLEAR` is enabled, the local margin cleanup is persisted so it survives the main loop reload of trading state.
- Keep invariant runtime/throttle persisted only to the separate invariants meta file and avoid writing those fields into `executor_state.json`.
- Prevent cross-test invariant state bleed by making test invariant state filenames unique per test.

### Description
- After computing `has_debt` and updating `rt[...]` and `inv_runtime["I13"]`, call `_meta_mark_dirty()` and `_meta_save(nowv)` to persist exchange-check backoff even when no WARN/ERROR is emitted.
- When `has_debt` is false and `_i13_clear_state_on_exchange_clear()` is true, remove `borrowed_assets`/`borrowed_by_trade` from `st["margin"]` and, if `save_state` is provided, call `save_state(st)` inside a `suppress(Exception)` block so the trading state change is persisted.
- Leave all invariant runtime/throttle persistence in the separate invariants meta mechanism and do not write these fields into `executor_state.json`.
- Update `test/test_invariants_margin.py` to set a per-test `INVAR_STATE_FN` pointing at a unique temporary filename so invariant meta files do not leak between tests.

### Testing
- Ran `python -m py_compile executor_mod/invariants.py` and it succeeded with no syntax errors.
- Ran `python -m pytest -q` but test collection failed due to missing third-party packages `requests` and `pandas` in the environment, causing import errors during collection.
- The change is tight-scoped to `executor_mod/invariants.py` and `test/test_invariants_margin.py` and unit tests that do run for invariants should now persist meta and cleared margin state as intended.
- No automated tests were observed to fail due to the code changes themselves before the dependency-related collection abort.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962fdae96408323b09cd83b97ef86ef)