### PR TITLE
Restore default 300s I13 grace when unset or blank

### DIFF
--- a/executor_mod/invariants.py
+++ b/executor_mod/invariants.py
@@ -258,10 +258,10 @@ def _inv_runtime() -> Dict[str, Any]:
 
 def _i13_grace_sec() -> float:
     try:
-        val = ENV.get("I13_GRACE_SEC")
-        if val is None:
-            val = ENV.get("INVAR_GRACE_SEC")
-        return float(300 if val is None else val)
+        val = ENV.get("I13_GRACE_SEC", None)
+        if val is None or str(val).strip() == "":
+            return 300.0
+        return float(val)
     except Exception:
         return 300.0
 


### PR DESCRIPTION
### Motivation
- Ensure a safe default grace period of 300 seconds for the I13 exchange-check invariant when `I13_GRACE_SEC` is not provided.
- Avoid surprising behavior when `I13_GRACE_SEC` is empty or blank, and prefer a conservative fail-loud default for production execution.
- Keep changes minimal and focused on reliability of invariants and reconciliation logic.

### Description
- Change `executor_mod/invariants.py` so `_i13_grace_sec()` returns `300.0` if `I13_GRACE_SEC` is unset or an empty/blank string.
- Stop falling back to `INVAR_GRACE_SEC` inside `_i13_grace_sec()` so explicit `I13_GRACE_SEC` is required to override the 300s default.
- The edited function is ` _i13_grace_sec()` in `executor_mod/invariants.py` (lines ~259-266).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963b6821ea08323877853be3ea1c2c7)