### PR TITLE
Use FEED_DIR for analyzer feed path

### DIFF
--- a/volume-alert/analyzer.py
+++ b/volume-alert/analyzer.py
@@ -5,7 +5,7 @@ import requests
 from typing import Tuple
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
-feed_dir = os.path.join(script_dir, "feed")
+feed_dir = os.getenv("FEED_DIR", os.path.join(script_dir, "feed"))
 csv_file = os.path.join(feed_dir, "aggregated.csv")
 
 N8N_URL = "http://n8n:5678/webhook/volume-alert"  # Production URL


### PR DESCRIPTION
### Motivation
- Fix path mismatch between aggregator and analyzer so analyzer can read the same feed directory used by the aggregator.
- Ensure local runs can point analyzer to `data/feed` via the `FEED_DIR` environment variable.
- Preserve existing default behavior when `FEED_DIR` is not set to remain backward compatible.

### Description
- Replace the static `feed_dir` definition with `feed_dir = os.getenv("FEED_DIR", os.path.join(script_dir, "feed"))` in `volume-alert/analyzer.py`.
- Keep `csv_file = os.path.join(feed_dir, "aggregated.csv")` unchanged so only the feed directory source is configurable.
- No other logic, triggers, or message formats were modified.

### Testing
- No automated tests were run for this change.
- Manual verification can be done by setting `FEED_DIR` to a different path and confirming the analyzer reads `aggregated.csv` from that directory.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963e7f889808323b233513a34e8f3a2)