### PR TITLE
Clarify and harden aggregated.csv tail reader behavior

### DIFF
--- a/executor_mod/trail.py
+++ b/executor_mod/trail.py
@@ -70,19 +70,24 @@ def _log_event(action: str, **fields: Any) -> None:
 def _read_last_close_prices_from_agg_csv(path: str, n_rows: int) -> list[float]:
     """
     Read last N ClosePrice values from aggregated.csv (v2 strict schema).
-    FAIL-LOUD on schema mismatch or malformed rows.
+    - FAIL-LOUD on schema mismatch (header != expected v2).
+    - Fail-closed (return []) if file is missing/empty (startup/rotation).
+    - Malformed data rows are skipped (best-effort tail parsing).
     """
     if int(n_rows or 0) <= 0:
         return []
     n_rows = int(n_rows)
     closes = deque(maxlen=n_rows)
-    _assert_agg_header_v2(path)
-
     close_idx = AGG_HEADER_V2.index("ClosePrice")
 
     # Prefer injected tail reader for performance; fallback to full scan if not provided.
     if read_tail_lines is not None:
+        # Important: preserve fail-closed startup behavior when file doesn't exist yet.
+        # executor.read_tail_lines typically catches FileNotFoundError and returns [].
         lines = read_tail_lines(path, n_rows + 5)  # a few extra lines for safety
+        if not lines:
+            return []
+        _assert_agg_header_v2(path)
         for ln in lines:
             ln = ln.strip()
             if not ln or ln.startswith("Timestamp"):
@@ -95,6 +100,10 @@ def _read_last_close_prices_from_agg_csv(path: str, n_rows: int) -> list[float]:
             except Exception:
                 continue
     else:
+        try:
+            _assert_agg_header_v2(path)
+        except FileNotFoundError:
+            return []
         with open(path, "r", encoding="utf-8-sig", newline="") as f:
             reader = csv.reader(f)
             next(reader, None)  # header


### PR DESCRIPTION
### Motivation
- Prevent startup crashes when `aggregated.csv` is not yet present while preserving strict schema checks when data exists.
- Ensure the trailing-stop / aggregated-data consumers see a safe, empty state instead of raising on missing tail data.
- Make tail parsing best-effort by skipping malformed rows while keeping header validation when data is present.

### Description
- Expanded the `_read_last_close_prices_from_agg_csv` docstring to document fail-loud/fail-closed and row-skipping behavior.
- When an injected `read_tail_lines` returns no lines the function now returns `[]` immediately to preserve fail-closed startup behavior.
- Header validation via `_assert_agg_header_v2(path)` is performed only when tail/full data is present, and the full-scan path now catches `FileNotFoundError` and returns `[]`.
- Existing parsing logic unchanged: malformed rows are skipped and valid `ClosePrice` values are collected into the result.

### Testing
- No automated tests were run against these changes.
- The change was committed locally and the modified file updated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964f1551c78832394bca3d414c0f1e4)