### PR TITLE
Use HiPrice/LowPrice swings for trailing stops and update tests

### DIFF
--- a/test/test_trail.py
+++ b/test/test_trail.py
@@ -105,7 +105,7 @@ class TestTrailModule(unittest.TestCase):
         self._configure_with_file(env)
         pos = {"side": "LONG"}
         stop = trail._trail_desired_stop_from_agg(pos)
-        self.assertEqual(stop, 7.5)
+        self.assertEqual(stop, 7.4)
 
     def test_trail_desired_stop_short(self) -> None:
         rows = [
@@ -125,7 +125,7 @@ class TestTrailModule(unittest.TestCase):
         self._configure_with_file(env)
         pos = {"side": "SHORT"}
         stop = trail._trail_desired_stop_from_agg(pos)
-        self.assertEqual(stop, 4)
+        self.assertEqual(stop, 4.1)
 
     def test_trail_desired_stop_no_path(self) -> None:
         rows = [


### PR DESCRIPTION
### Motivation
- Trailing stop computation should use intra-bar extremes (swing `HiPrice`/`LowPrice`) instead of `Close` to better reflect true swing points.
- Aggregated CSV v2 contains `HiPrice` and `LowPrice` columns which must be read to detect swings reliably.
- Preserve existing strict v2 header/schema checks and fail-loud semantics when reading aggregated CSV data.
- Update unit expectations because swing input changed from `Close` to `HiPrice`/`LowPrice` producing different numeric stops.

### Description
- Added `
_read_last_low_prices_from_agg_csv` and `
_read_last_high_prices_from_agg_csv` to read tails of `LowPrice` and `HiPrice` from the aggregated CSV while skipping malformed rows.
- Switched `
_trail_desired_stop_from_agg` to select the `LowPrice` series for `LONG` and the `HiPrice` series for `SHORT`, then call `
_find_last_fractal_swing` on that series; docstring updated to describe the new behavior.
- Kept existing confirmation logic that still reads recent closes for trail confirmation and preserved header/schema checks via `
_assert_agg_header_v2` and `read_tail_lines` usage.
- Updated test assertions in `test/test_trail.py` to match new expected stops (`7.4` for LONG and `4.1` for SHORT).

### Testing
- No automated tests were run as part of this change.
- Unit expectations in `test/test_trail.py` were updated to reflect the new swing-based stop outputs.
- Recommend running the unit test suite with `pytest -q` to validate behavior after the change.
- If CI is available, ensure the repo `pytest`/CI run passes after applying these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964ff58b4948323a7048fce9a161fb6)