### PR TITLE
Make swing_stop_far NaN-safe for aggregated HiPrice/LowPrice

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -510,10 +510,18 @@ def swing_stop_far(df: pd.DataFrame, i: int, side: str, entry: float) -> float:
     else:
         lookback = df.iloc[max(0, i - ENV["SWING_MINS"]): i + 1]
         if side == "BUY":
-            swing = float(lookback["price"].min())
+            swing_col = "LowPrice" if "LowPrice" in lookback.columns else "price"
+            s = lookback[swing_col].dropna()
+            if s.empty:
+                s = lookback["price"].dropna()
+            swing = pct_sl if s.empty else float(s.min())
             sl = min(pct_sl, swing)
         else:
-            swing = float(lookback["price"].max())
+            swing_col = "HiPrice" if "HiPrice" in lookback.columns else "price"
+            s = lookback[swing_col].dropna()
+            if s.empty:
+                s = lookback["price"].dropna()
+            swing = pct_sl if s.empty else float(s.max())
             sl = max(pct_sl, swing)
 
     # Safety: enforce correct side and rounding


### PR DESCRIPTION
### Motivation
- Ensure `swing_stop_far` uses aggregated `LowPrice`/`HiPrice` when available but does not pick up `NaN` values or crash when those columns are present yet empty.
- Preserve existing percent-SL math, rounding rules and safety invariants while handling missing/NaN inputs.
- Keep the diff minimal and fail-closed (fall back to `price` or `pct_sl`), avoiding any silent auto-fix of trading invariants.

### Description
- Updated `swing_stop_far` to compute `s = lookback[swing_col].dropna()` and, if empty, fall back to `lookback["price"].dropna()`, and finally to `pct_sl` when both are empty for BUY/SELL branches.
- Left downstream logic unchanged: safety enforcement using `ENV["TICK_SIZE"]` and final rounding via `floor_to_step` / `ceil_to_step` remain intact.
- Added two unit tests in `test/test_executor.py`: `test_swing_stop_far_uses_agg_high_low` to assert BUY uses `LowPrice` and SELL uses `HiPrice`, and `test_swing_stop_far_nan_fallbacks_to_price` to assert fallback to `price` when aggregated columns are all `NaN`.
- Changes are limited to NaN-safety logic and tests; no behavioral changes when aggregated columns are absent or valid.

### Testing
- Ran `python -m unittest -q` which failed during collection due to missing dependencies (`pandas`, `requests`) so tests could not be executed in this environment.
- Ran `pytest -q` which similarly failed for the same missing dependencies and did not run the new tests here.
- The new tests are present and expected to pass once CI or the local environment installs `pandas` (and `requests` for other test modules).
- Recommend installing `pandas` and `requests` in CI and running `python -m unittest test/test_executor.py -k swing_stop_far` or `pytest test/test_executor.py::TestExecutorV15::test_swing_stop_far_uses_agg_high_low -q` to validate the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69652f1a57cc8323934f1fdfdf2f3bc7)