### PR TITLE
Fix Decimal step rounding for tick sizes

### DIFF
--- a/executor_mod/risk_math.py
+++ b/executor_mod/risk_math.py
@@ -15,19 +15,19 @@ def configure(env: Dict[str, Any]) -> None:
     ENV = env
 
 def floor_to_step(x: float, step: Decimal) -> float:
-    step = Decimal(step)
-    d = (Decimal(str(x)) / step).quantize(Decimal("1"), rounding=ROUND_FLOOR) * step
-    return float(d)
+    step_d = Decimal(str(step))
+    units = (Decimal(str(x)) / step_d).to_integral_value(rounding=ROUND_FLOOR)
+    return float(units * step_d)
 
 def ceil_to_step(x: float, step: Decimal) -> float:
-    step = Decimal(step)
-    d = (Decimal(str(x)) / step).quantize(Decimal("1"), rounding=ROUND_CEILING) * step
-    return float(d)
+    step_d = Decimal(str(step))
+    units = (Decimal(str(x)) / step_d).to_integral_value(rounding=ROUND_CEILING)
+    return float(units * step_d)
 
 def round_nearest_to_step(x: float, step: Decimal) -> float:
-    step = Decimal(step)
-    d = (Decimal(str(x)) / step).quantize(Decimal("1"), rounding=ROUND_HALF_UP) * step
-    return float(d)
+    step_d = Decimal(str(step))
+    units = (Decimal(str(x)) / step_d).to_integral_value(rounding=ROUND_HALF_UP)
+    return float(units * step_d)
 
 def _decimals_from_step(step: Decimal) -> int:
     """Number of decimal places implied by a step (tick/lot)."""
@@ -104,4 +104,3 @@ def split_qty_3legs_place(qty_total_r: float) -> Tuple[float, float, float]:
     if qty1 <= 0 or qty2 <= 0 or qty3 < 0:
         raise RuntimeError(f"Invalid qty split: qty_total={qty_total_r} qty1={qty1} qty2={qty2} qty3={qty3}")
     return qty1, qty2, qty3
-


### PR DESCRIPTION
### Motivation
- Tests showed rounding artifacts when `TICK_SIZE` is decimal (e.g., `0.1`) causing values like `90.0` to become `89.9` after floor/ceil rounding.
- The root cause is floating/quantize interactions producing non-integer unit counts for decimal steps.
- Make rounding deterministic for common decimal steps (`0.1`, `0.01`, `0.001`) and preserve already-aligned values.
- Avoid touching `swing_stop_far` logic or tests; fix only the rounding helpers.

### Description
- Normalized step inputs using `Decimal(str(step))` to avoid float-to-Decimal precision issues.
- Reimplemented `floor_to_step`, `ceil_to_step`, and `round_nearest_to_step` to compute integer `units` via `to_integral_value(rounding=...)` and then return `float(units * step_d)`.
- Changes applied to `executor_mod/risk_math.py` only; no other logic touched.
- This ensures values already aligned to the step remain unchanged (e.g., `90.0` with step `0.1` stays `90.0`).

### Testing
- Ran `python -m unittest -q` (attempted); collection/run failed due to missing external dependencies `requests` and `pandas` in the environment, so tests could not complete.
- Ran `pytest -q` (attempted); collection interrupted for the same missing dependencies (`requests`, `pandas`).
- The targeted rounding regressions are addressed by the helper changes; in an environment with test deps installed the two failing tests in `test/test_executor.py` (BUY side floor edge cases) should pass.
- To validate locally: install test deps (`pip install -r requirements.txt` or at least `pandas requests`) and run `python -m unittest -q` and `pytest -q`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965382e6a588323a205e2b8b5433c1a)