### PR TITLE
Reset exchange_snapshot singleton between tests to avoid cross-test leakage

### DIFF
--- a/executor_mod/exchange_snapshot.py
+++ b/executor_mod/exchange_snapshot.py
@@ -100,6 +100,12 @@ def get_snapshot() -> ExchangeSnapshot:
     return _snapshot
 
 
+def reset_snapshot() -> None:
+    """Reset the global ExchangeSnapshot instance (test isolation helper)."""
+    global _snapshot
+    _snapshot = ExchangeSnapshot()
+
+
 def refresh_snapshot(
     symbol: str,
     source: str,

--- a/test/test_exchange_snapshot.py
+++ b/test/test_exchange_snapshot.py
@@ -6,10 +6,13 @@ Tests for exchange_snapshot module.
 
 import unittest
 import time
-from executor_mod.exchange_snapshot import ExchangeSnapshot, get_snapshot, refresh_snapshot
+from executor_mod.exchange_snapshot import ExchangeSnapshot, get_snapshot, refresh_snapshot, reset_snapshot
 
 
 class TestExchangeSnapshot(unittest.TestCase):
+    def setUp(self):
+        reset_snapshot()
+
     def test_snapshot_creation(self):
         """Test basic snapshot creation and freshness."""
         snap = ExchangeSnapshot()

--- a/test/test_executor.py
+++ b/test/test_executor.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch, MagicMock
 import pandas as pd
 import executor
+from executor_mod.exchange_snapshot import reset_snapshot
 from copy import deepcopy
 
 
@@ -15,6 +16,8 @@ def _stop_after_n_sleeps(n: int):
 
 
 class TestExecutorV15(unittest.TestCase):
+    def setUp(self):
+        reset_snapshot()
 
     def test_swing_stop_far_uses_agg_high_low(self):
         df = pd.DataFrame({


### PR DESCRIPTION
### Motivation
- The global ExchangeSnapshot singleton cached openOrders across test modules which could leave the snapshot "fresh" and cause `manage_v15_position` to use stale open-order data, producing extra keys like `missing_not_filled`/`sl_status_next_s` and preventing slot cleanup after SL fill.
- This manifested only when running the full test suite because earlier tests refresh the global snapshot and leave it fresh, while running the executor test in isolation starts from a clean snapshot and passes.

### Description
- Add `reset_snapshot()` helper to `executor_mod/exchange_snapshot.py` that reinitializes the module-level `_snapshot` singleton.
- Call `reset_snapshot()` from `TestExchangeSnapshot.setUp` to guarantee exchange snapshot tests start from a clean instance.
- Call `reset_snapshot()` from `TestExecutorV15.setUp` in `test/test_executor.py` to prevent leaked snapshot state from other tests affecting `manage_v15_position` behavior.

### Testing
- Ran `python -m unittest -q` in this environment and it surfaced unrelated import errors for missing external packages (`pandas`, `requests`), so the full suite could not be validated here.
- Ran `python -m unittest test.test_executor.TestExecutorV15.test_sl_filled_cancels_tp1_tp2_even_if_openorders_fail -v` but import failed due to missing `pandas` in this environment and could not be executed end-to-end here; the change is targeted at removing snapshot leakage and should resolve the original cross-test failure when the test environment has required deps installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b9a615974832391095fb1d44c6359)