### PR TITLE
Reset snapshot fields in test helper

### DIFF
--- a/executor_mod/exchange_snapshot.py
+++ b/executor_mod/exchange_snapshot.py
@@ -100,10 +100,15 @@ def get_snapshot() -> ExchangeSnapshot:
     return _snapshot
 
 
-def reset_snapshot() -> None:
-    """Reset the global ExchangeSnapshot instance (test isolation helper)."""
+def reset_snapshot_for_tests() -> None:
+    """Tests only: reset the global ExchangeSnapshot to a pristine state."""
     global _snapshot
-    _snapshot = ExchangeSnapshot()
+    _snapshot.ts_updated = 0.0
+    _snapshot.ok = False
+    _snapshot.error = None
+    _snapshot.source = ""
+    _snapshot.symbol = ""
+    _snapshot.open_orders = None
 
 
 def refresh_snapshot(

--- a/test/test_exchange_snapshot.py
+++ b/test/test_exchange_snapshot.py
@@ -6,12 +6,18 @@ Tests for exchange_snapshot module.
 
 import unittest
 import time
-from executor_mod.exchange_snapshot import ExchangeSnapshot, get_snapshot, refresh_snapshot, reset_snapshot
+from executor_mod.exchange_snapshot import (
+    ExchangeSnapshot,
+    get_snapshot,
+    refresh_snapshot,
+    reset_snapshot_for_tests,
+)
 
 
 class TestExchangeSnapshot(unittest.TestCase):
     def setUp(self):
-        reset_snapshot()
+        super().setUp()
+        reset_snapshot_for_tests()
 
     def test_snapshot_creation(self):
         """Test basic snapshot creation and freshness."""

--- a/test/test_executor.py
+++ b/test/test_executor.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import patch, MagicMock
 import pandas as pd
 import executor
-from executor_mod.exchange_snapshot import reset_snapshot
+from executor_mod.exchange_snapshot import reset_snapshot_for_tests
 from copy import deepcopy
 
 
@@ -17,7 +17,8 @@ def _stop_after_n_sleeps(n: int):
 
 class TestExecutorV15(unittest.TestCase):
     def setUp(self):
-        reset_snapshot()
+        super().setUp()
+        reset_snapshot_for_tests()
 
     def test_swing_stop_far_uses_agg_high_low(self):
         df = pd.DataFrame({


### PR DESCRIPTION
### Motivation
- Ensure test isolation by returning the global `ExchangeSnapshot` singleton to a pristine state without replacing the instance so existing references remain valid.
- Make the reset helper explicitly tests-only and more deterministic for test `setUp` usage.
- Improve test `setUp` robustness by ensuring `super().setUp()` is invoked in modified tests.

### Description
- Change `reset_snapshot_for_tests()` in `executor_mod/exchange_snapshot.py` to clear the existing `_snapshot` fields in place instead of re-instantiating it, preserving the original singleton object.
- Update `test/test_exchange_snapshot.py` to import `reset_snapshot_for_tests`, call `super().setUp()` and invoke `reset_snapshot_for_tests()` in `setUp()`.
- Update `test/test_executor.py` to import `reset_snapshot_for_tests`, call `super().setUp()` and invoke `reset_snapshot_for_tests()` in `setUp()`.
- The change avoids breaking code that holds references to the global `_snapshot` instance while restoring snapshot state for tests.

### Testing
- Ran the unit test suite with `python -m unittest -q`, which discovered `62` tests and produced `10` import errors due to missing external dependencies (`requests` / `pandas`) in the environment, so a full green run could not be completed.
- No test failures were observed that were attributable to the modified helper in the executed run despite the environment import errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b9fdbe9588323b4f2881d9cd27c90)