### PR TITLE
Align manager report fee and pnl totals

### DIFF
--- a/executor_mod/binance_api.py
+++ b/executor_mod/binance_api.py
@@ -387,6 +387,40 @@ def open_orders(symbol: str) -> List[Dict[str, Any]]:
     return list(j) if isinstance(j, list) else []
 
 
+def my_trades(
+    symbol: str,
+    *,
+    order_id: Optional[int] = None,
+    start_time: Optional[int] = None,
+    end_time: Optional[int] = None,
+    limit: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Return account trades for a symbol.
+
+    Spot:   GET /api/v3/myTrades
+    Margin: GET /sapi/v1/margin/myTrades
+    """
+    env = _env()
+    mode = str(env.get("TRADE_MODE", "spot")).strip().lower()
+    params: Dict[str, Any] = {"symbol": symbol}
+    if order_id is not None:
+        params["orderId"] = int(order_id)
+    if start_time is not None:
+        params["startTime"] = int(start_time)
+    if end_time is not None:
+        params["endTime"] = int(end_time)
+    if limit is not None:
+        params["limit"] = int(limit)
+
+    if mode == "margin":
+        params["isIsolated"] = _tf(env.get("MARGIN_ISOLATED", "FALSE"))
+        j = _binance_signed_request("GET", "/sapi/v1/margin/myTrades", params)
+        return list(j) if isinstance(j, list) else []
+
+    j = _binance_signed_request("GET", "/api/v3/myTrades", params)
+    return list(j) if isinstance(j, list) else []
+
+
 def place_order_raw(endpoint_params: Dict[str, Any]) -> Dict[str, Any]:
     """Place an order in current TRADE_MODE.
 

--- a/executor_mod/reporting.py
+++ b/executor_mod/reporting.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Trade reporting (Reporting Spec v1).
+
+Best-effort, read-only, deterministic reporting. Never blocks execution.
+"""
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+REPORTS_PATH = "/data/reports/trades.jsonl"
+
+
+def _ensure_dir(path: str) -> None:
+    d = os.path.dirname(path)
+    if d:
+        os.makedirs(d, exist_ok=True)
+
+
+def _iso_date(ts: Optional[str]) -> Optional[str]:
+    if not ts:
+        return None
+    try:
+        if ts.endswith("Z"):
+            ts = ts[:-1] + "+00:00"
+        dt = datetime.fromisoformat(ts)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.date().isoformat()
+    except Exception:
+        return None
+
+
+def _exit_type(reason: str) -> str:
+    r = str(reason or "").strip().upper()
+    if "FAILSAFE_FLATTEN" in r:
+        return "FAILSAFE_FLATTEN"
+    if "EXIT_CLEANUP" in r or "CLEANUP" in r:
+        return "EXIT_CLEANUP"
+    if "MISSING" in r:
+        return "MISSING"
+    if "ABORT" in r:
+        return "ABORTED"
+    if "TRAIL" in r:
+        return "NORMAL_TRAIL"
+    if r == "TP1":
+        return "NORMAL_TP1"
+    if r == "TP2":
+        return "NORMAL_TP2"
+    if r == "SL":
+        return "NORMAL_SL"
+    return "ABORTED"
+
+
+def _entry_price(pos: Dict[str, Any]) -> Optional[float]:
+    for key in ("entry_actual", "entry"):
+        try:
+            v = pos.get(key)
+            if v is not None:
+                return float(v)
+        except Exception:
+            continue
+    prices = pos.get("prices") or {}
+    try:
+        v = prices.get("entry")
+        if v is not None:
+            return float(v)
+    except Exception:
+        return None
+    return None
+
+
+def _sum_leg_field(exit_leg_orders: Dict[str, Any], field: str) -> Optional[float]:
+    total = 0.0
+    seen = False
+    for leg in ("tp1", "tp2", "sl", "trail"):
+        leg_data = exit_leg_orders.get(leg)
+        if not isinstance(leg_data, dict):
+            continue
+        try:
+            val = leg_data.get(field)
+            if val is None:
+                continue
+            total += float(val)
+            seen = True
+        except Exception:
+            continue
+    return total if seen else None
+
+
+def _all_leg_fields_present(exit_leg_orders: Dict[str, Any], fields: list[str]) -> bool:
+    for leg in ("tp1", "tp2", "sl", "trail"):
+        leg_data = exit_leg_orders.get(leg)
+        if not isinstance(leg_data, dict):
+            continue
+        for field in fields:
+            if leg_data.get(field) in (None, ""):
+                return False
+    return True
+
+
+def build_trade_report_internal(st: Dict[str, Any], pos: Dict[str, Any], close_reason: str) -> Dict[str, Any]:
+    last_closed = st.get("last_closed") or {}
+    closed_at = last_closed.get("ts")
+    trade_key = pos.get("trade_key") or pos.get("client_id") or pos.get("order_id")
+    exit_leg_orders = (pos.get("orders") or {}).get("fills") or {}
+
+    entry_price = _entry_price(pos)
+    qty_base_total = None
+    try:
+        qty_base_total = float(pos.get("qty"))
+    except Exception:
+        qty_base_total = None
+
+    exit_qty_total = _sum_leg_field(exit_leg_orders, "executedQty")
+    exit_quote_total = _sum_leg_field(exit_leg_orders, "cummulativeQuoteQty")
+    avg_exit_price = None
+    if exit_qty_total and exit_quote_total and exit_qty_total > 0:
+        avg_exit_price = float(exit_quote_total) / float(exit_qty_total)
+
+    fees_total_quote = _sum_leg_field(exit_leg_orders, "feeQuote")
+    pnl_quote = None
+    roi_pct = None
+    if (
+        entry_price is not None
+        and qty_base_total is not None
+        and exit_qty_total is not None
+        and exit_quote_total is not None
+        and fees_total_quote is not None
+        and _all_leg_fields_present(exit_leg_orders, ["executedQty", "cummulativeQuoteQty", "feeQuote"])
+    ):
+        entry_cost = float(entry_price) * float(qty_base_total)
+        side = str(pos.get("side") or "").upper()
+        if side == "SHORT":
+            gross = entry_cost - float(exit_quote_total)
+        else:
+            gross = float(exit_quote_total) - entry_cost
+        pnl_quote = gross - float(fees_total_quote)
+        if entry_cost > 0:
+            roi_pct = (pnl_quote / entry_cost) * 100.0
+
+    report_id = f"{trade_key}:{closed_at}"
+
+    return {
+        "report_id": report_id,
+        "trade_key": trade_key,
+        "symbol": st.get("meta", {}).get("symbol") or os.getenv("SYMBOL"),
+        "side": pos.get("side"),
+        "opened_at": pos.get("opened_at"),
+        "closed_at": closed_at,
+        "close_reason": close_reason,
+        "exit_type": _exit_type(close_reason),
+        "status_at_close": pos.get("status"),
+        "qty_base_total": qty_base_total,
+        "entry_price": entry_price,
+        "exit_leg_orders": exit_leg_orders,
+        "exit_qty_total": exit_qty_total,
+        "exit_quote_total": exit_quote_total,
+        "avg_exit_price": avg_exit_price,
+        "fees_total_quote": fees_total_quote,
+        "pnl_quote": pnl_quote,
+        "roi_pct": roi_pct,
+        "tp1_hit": bool(pos.get("tp1_done")),
+        "tp2_hit": bool(pos.get("tp2_done")),
+        "sl_hit": bool(pos.get("sl_done")),
+        "trail_active_at_close": bool(pos.get("trail_active")),
+        "reconciliation_notes": pos.get("reconciliation_notes"),
+    }
+
+
+def build_trade_report_public(internal: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "date": _iso_date(internal.get("closed_at")),
+        "symbol": internal.get("symbol"),
+        "side": internal.get("side"),
+        "qty_base_total": internal.get("qty_base_total"),
+        "entry_price": internal.get("entry_price"),
+        "exit_qty_total": internal.get("exit_qty_total"),
+        "avg_exit_price": internal.get("avg_exit_price"),
+        "fees_total_quote": internal.get("fees_total_quote"),
+        "pnl_quote": internal.get("pnl_quote"),
+        "roi_pct": internal.get("roi_pct"),
+        "exit_type": internal.get("exit_type"),
+        "tp1_hit": internal.get("tp1_hit"),
+        "tp2_hit": internal.get("tp2_hit"),
+    }
+
+
+def _append_jsonl(path: str, payload: Dict[str, Any]) -> None:
+    _ensure_dir(path)
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(payload, ensure_ascii=False, separators=(",", ":")) + "\n")
+
+
+def report_trade_close(st: Dict[str, Any], pos: Dict[str, Any], close_reason: str) -> None:
+    """Best-effort report writer. Never raises."""
+    try:
+        internal = build_trade_report_internal(st, pos, close_reason)
+        report_id = internal.get("report_id")
+        if report_id and st.get("last_reported_report_id") == report_id:
+            return
+        _append_jsonl(REPORTS_PATH, internal)
+        st["last_reported_report_id"] = report_id
+    except Exception:
+        return

--- a/executor_mod/state_store.py
+++ b/executor_mod/state_store.py
@@ -33,6 +33,7 @@ def load_state() -> Dict[str, Any]:
     st["meta"].setdefault("seen_keys", [])
     st.setdefault("position", None)
     st.setdefault("last_closed", None)
+    st.setdefault("last_reported_report_id", None)
     st.setdefault("cooldown_until", 0.0)
     st.setdefault("lock_until", 0.0)
     baseline = st.get("baseline")

--- a/tools/enrich_trades_with_fees.py
+++ b/tools/enrich_trades_with_fees.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Offline fee enrichment for TradeReportInternal (Policy A, strict).
+
+Reads:  /data/reports/trades.jsonl
+Writes: /data/reports/trades_enriched.jsonl
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+from executor_mod import binance_api
+
+INPUT_PATH_DEFAULT = "/data/reports/trades.jsonl"
+OUTPUT_PATH_DEFAULT = "/data/reports/trades_enriched.jsonl"
+TMP_SUFFIX = ".tmp"
+
+
+def _load_env() -> Dict[str, Any]:
+    return {
+        "BINANCE_API_KEY": os.getenv("BINANCE_API_KEY", ""),
+        "BINANCE_API_SECRET": os.getenv("BINANCE_API_SECRET", ""),
+        "BINANCE_BASE_URL": os.getenv("BINANCE_BASE_URL", "https://api.binance.com"),
+        "BINANCE_API_BASES": os.getenv("BINANCE_API_BASES", ""),
+        "RECV_WINDOW": int(os.getenv("RECV_WINDOW", "5000")),
+        "TRADE_MODE": os.getenv("TRADE_MODE", "spot"),
+        "MARGIN_ISOLATED": os.getenv("MARGIN_ISOLATED", "FALSE"),
+    }
+
+
+def _split_symbol_guess(symbol: str) -> Tuple[str, str]:
+    s = (symbol or "").strip().upper()
+    suffixes = (
+        "USDT",
+        "USDC",
+        "FDUSD",
+        "BUSD",
+        "TUSD",
+        "USDP",
+        "DAI",
+        "BTC",
+        "ETH",
+        "BNB",
+    )
+    for suf in suffixes:
+        if s.endswith(suf) and len(s) > len(suf):
+            return s[:-len(suf)], suf
+    return s, ""
+
+
+def _safe_float(v: Any) -> Optional[float]:
+    try:
+        return float(v)
+    except Exception:
+        return None
+
+
+def _read_jsonl(path: str) -> Tuple[List[Dict[str, Any]], int]:
+    records: List[Dict[str, Any]] = []
+    skipped = 0
+    if not os.path.exists(path):
+        return records, skipped
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except Exception:
+                skipped += 1
+    return records, skipped
+
+
+def _write_jsonl(path: str, records: List[Dict[str, Any]]) -> None:
+    tmp = path + TMP_SUFFIX
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(tmp, "w", encoding="utf-8") as f:
+        for rec in records:
+            f.write(json.dumps(rec, ensure_ascii=False, separators=(",", ":")) + "\n")
+    os.replace(tmp, path)
+
+
+def _append_note(rec: Dict[str, Any], note: str) -> None:
+    if not note:
+        return
+    prev = rec.get("reconciliation_notes")
+    if not prev:
+        rec["reconciliation_notes"] = note
+        return
+    if note in str(prev):
+        return
+    rec["reconciliation_notes"] = f"{prev}; {note}"
+
+
+def _fetch_trades_with_retry(symbol: str, order_id: int, retries: int = 3) -> List[Dict[str, Any]]:
+    delay = 0.5
+    last_err: Optional[str] = None
+    for _ in range(max(1, retries)):
+        try:
+            return binance_api.my_trades(symbol, order_id=order_id, limit=1000)
+        except Exception as exc:
+            last_err = str(exc)
+            time.sleep(delay)
+            delay = min(delay * 2.0, 5.0)
+    raise RuntimeError(last_err or "my_trades_failed")
+
+
+def _sum_commission_quote(trades: List[Dict[str, Any]], quote_asset: str) -> Tuple[Optional[float], Optional[str]]:
+    total = 0.0
+    seen = False
+    for tr in trades:
+        if not isinstance(tr, dict):
+            continue
+        asset = str(tr.get("commissionAsset") or "").upper()
+        if asset and asset != quote_asset:
+            return None, "commission_asset_mismatch"
+        commission = _safe_float(tr.get("commission"))
+        if commission is None:
+            continue
+        total += commission
+        seen = True
+    if not seen:
+        return None, "no_commission"
+    return total, None
+
+
+def _compute_exit_quote_total(rec: Dict[str, Any]) -> Optional[float]:
+    val = _safe_float(rec.get("exit_quote_total"))
+    if val is not None:
+        return val
+    exit_leg_orders = rec.get("exit_leg_orders") or {}
+    total = 0.0
+    seen = False
+    for leg in ("tp1", "tp2", "sl", "trail"):
+        leg_data = exit_leg_orders.get(leg)
+        if not isinstance(leg_data, dict):
+            continue
+        leg_val = _safe_float(leg_data.get("cummulativeQuoteQty"))
+        if leg_val is None:
+            continue
+        total += leg_val
+        seen = True
+    return total if seen else None
+
+
+def _enrich_record(rec: Dict[str, Any], cache: Dict[Tuple[str, int], List[Dict[str, Any]]]) -> Dict[str, Any]:
+    rec = dict(rec)
+    symbol = str(rec.get("symbol") or "").upper()
+    _, quote_asset = _split_symbol_guess(symbol)
+    exit_leg_orders = rec.get("exit_leg_orders") or {}
+    if not isinstance(exit_leg_orders, dict):
+        exit_leg_orders = {}
+        rec["exit_leg_orders"] = exit_leg_orders
+
+    fees_total_quote: Optional[float] = 0.0
+    fees_allowed = True
+    had_leg = False
+    for leg in ("tp1", "tp2", "sl", "trail"):
+        leg_data = exit_leg_orders.get(leg)
+        if not isinstance(leg_data, dict):
+            continue
+        order_id = leg_data.get("orderId")
+        if order_id in (None, 0, "", "0"):
+            continue
+        had_leg = True
+        oid = int(order_id)
+        cache_key = (symbol, oid)
+        trades = cache.get(cache_key)
+        if trades is None:
+            trades = _fetch_trades_with_retry(symbol, oid)
+            cache[cache_key] = trades
+        fee, fee_err = _sum_commission_quote(trades, quote_asset)
+        if fee_err:
+            fees_allowed = False
+            leg_data["feeQuote"] = None
+            _append_note(rec, f"fee_{leg}_{fee_err}")
+        else:
+            leg_data["feeQuote"] = fee
+            fees_total_quote = (fees_total_quote or 0.0) + float(fee or 0.0)
+
+    if not had_leg:
+        fees_allowed = False
+        _append_note(rec, "no_exit_legs")
+
+    if not fees_allowed:
+        rec["fees_total_quote"] = None
+        rec["pnl_quote"] = None
+        rec["roi_pct"] = None
+        return rec
+
+    rec["fees_total_quote"] = fees_total_quote
+    entry_price = _safe_float(rec.get("entry_price"))
+    qty_base_total = _safe_float(rec.get("qty_base_total"))
+    exit_quote_total = _compute_exit_quote_total(rec)
+    if entry_price is None or qty_base_total is None or exit_quote_total is None:
+        rec["pnl_quote"] = None
+        rec["roi_pct"] = None
+        _append_note(rec, "pnl_missing_inputs")
+        return rec
+
+    entry_cost = float(entry_price) * float(qty_base_total)
+    side = str(rec.get("side") or "").upper()
+    if side == "SHORT":
+        gross = entry_cost - float(exit_quote_total)
+    else:
+        gross = float(exit_quote_total) - entry_cost
+    pnl_quote = gross - float(fees_total_quote or 0.0)
+    rec["pnl_quote"] = pnl_quote
+    rec["roi_pct"] = (pnl_quote / entry_cost) * 100.0 if entry_cost > 0 else None
+    return rec
+
+
+def _load_existing_output(path: str) -> Dict[str, Dict[str, Any]]:
+    existing: Dict[str, Dict[str, Any]] = {}
+    if not os.path.exists(path):
+        return existing
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except Exception:
+                continue
+            report_id = rec.get("report_id")
+            if report_id:
+                existing[report_id] = rec
+    return existing
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Enrich TradeReportInternal with fees via myTrades.")
+    parser.add_argument("--input", default=INPUT_PATH_DEFAULT)
+    parser.add_argument("--output", default=OUTPUT_PATH_DEFAULT)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    env = _load_env()
+    binance_api.configure(env)
+
+    records, skipped = _read_jsonl(args.input)
+    existing = _load_existing_output(args.output) if args.output else {}
+    cache: Dict[Tuple[str, int], List[Dict[str, Any]]] = {}
+
+    enriched: List[Dict[str, Any]] = []
+    pnl_ok = 0
+    for rec in records:
+        report_id = rec.get("report_id")
+        if report_id and report_id in existing:
+            out_rec = existing[report_id]
+        else:
+            try:
+                out_rec = _enrich_record(rec, cache)
+            except Exception as exc:
+                out_rec = dict(rec)
+                out_rec["fees_total_quote"] = None
+                out_rec["pnl_quote"] = None
+                out_rec["roi_pct"] = None
+                _append_note(out_rec, f"enrich_error:{exc}")
+        if out_rec.get("pnl_quote") is not None:
+            pnl_ok += 1
+        enriched.append(out_rec)
+
+    if not args.dry_run:
+        _write_jsonl(args.output, enriched)
+
+    print(f"input_records={len(records)}")
+    print(f"enriched_records={len(enriched)}")
+    print(f"pnl_non_null={pnl_ok}")
+    print(f"invalid_json_skipped={skipped}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/make_manager_report.py
+++ b/tools/make_manager_report.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Generate manager report from enriched trades (offline, cron-safe)."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+INPUT_PATH_DEFAULT = "/data/reports/trades_enriched.jsonl"
+OUTPUT_PATH_DEFAULT = "/data/reports/manager_report.md"
+TMP_SUFFIX = ".tmp"
+
+
+def _parse_iso(ts: Optional[str]) -> Optional[datetime]:
+    if not ts:
+        return None
+    try:
+        if ts.endswith("Z"):
+            ts = ts[:-1] + "+00:00"
+        dt = datetime.fromisoformat(ts)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+    except Exception:
+        return None
+
+
+def _safe_float(v: Any) -> Optional[float]:
+    try:
+        return float(v)
+    except Exception:
+        return None
+
+
+def _read_jsonl(path: str) -> Tuple[List[Dict[str, Any]], int]:
+    records: List[Dict[str, Any]] = []
+    skipped = 0
+    if not os.path.exists(path):
+        return records, skipped
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except Exception:
+                skipped += 1
+    return records, skipped
+
+
+def _format_number(val: Optional[float]) -> str:
+    if val is None:
+        return "N/A"
+    if abs(val) >= 1:
+        return f"{val:.4f}"
+    return f"{val:.8f}"
+
+
+def _format_bool(val: Any) -> str:
+    if val is None:
+        return "N/A"
+    return "true" if bool(val) else "false"
+
+
+def _record_date(rec: Dict[str, Any]) -> Optional[str]:
+    closed_at = rec.get("closed_at")
+    dt = _parse_iso(closed_at) if closed_at else None
+    if dt:
+        return dt.date().isoformat()
+    date = rec.get("date")
+    if isinstance(date, str) and date:
+        return date
+    return None
+
+
+def _record_month(rec: Dict[str, Any]) -> Optional[str]:
+    closed_at = rec.get("closed_at")
+    dt = _parse_iso(closed_at) if closed_at else None
+    if dt:
+        return dt.strftime("%Y-%m")
+    date = rec.get("date")
+    if isinstance(date, str) and len(date) >= 7:
+        return date[:7]
+    return None
+
+
+def _write_markdown(path: str, content: str) -> None:
+    tmp = path + TMP_SUFFIX
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(tmp, "w", encoding="utf-8") as f:
+        f.write(content)
+    os.replace(tmp, path)
+
+
+def _summarize(records: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    summary: Dict[str, Dict[str, Any]] = defaultdict(lambda: {
+        "trades_total": 0,
+        "trades_with_pnl": 0,
+        "pnl_sum_quote": 0.0,
+        "fees_sum_quote": 0.0,
+        "tp1_hits": 0,
+        "tp2_hits": 0,
+        "entry_cost_sum": 0.0,
+    })
+    for rec in records:
+        month = _record_month(rec) or "N/A"
+        data = summary[month]
+        data["trades_total"] += 1
+
+        if bool(rec.get("tp1_hit")):
+            data["tp1_hits"] += 1
+        if bool(rec.get("tp2_hit")):
+            data["tp2_hits"] += 1
+
+        pnl = _safe_float(rec.get("pnl_quote"))
+        if pnl is not None:
+            data["trades_with_pnl"] += 1
+            data["pnl_sum_quote"] += pnl
+            entry_price = _safe_float(rec.get("entry_price"))
+            qty = _safe_float(rec.get("qty_base_total"))
+            if entry_price is not None and qty is not None:
+                entry_cost = entry_price * qty
+                if entry_cost > 0:
+                    data["entry_cost_sum"] += entry_cost
+
+        if pnl is not None:
+            fees = _safe_float(rec.get("fees_total_quote"))
+            if fees is not None:
+                data["fees_sum_quote"] += fees
+    return summary
+
+
+def _build_markdown(records: List[Dict[str, Any]], input_path: str) -> str:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    summary = _summarize(records)
+    lines: List[str] = []
+    lines.append(f"# Manager Report")
+    lines.append("")
+    lines.append(f"- Generated (UTC): {now}")
+    lines.append(f"- Input: {input_path}")
+    lines.append("")
+    lines.append("## Monthly Summary")
+    lines.append("")
+    lines.append("| month | trades_total | trades_with_pnl | pnl_sum_quote | roi_weighted_pct | fees_sum_quote | tp1_hit_rate | tp2_hit_rate |")
+    lines.append("| --- | --- | --- | --- | --- | --- | --- | --- |")
+
+    for month in sorted(summary.keys()):
+        data = summary[month]
+        trades_total = data["trades_total"]
+        trades_with_pnl = data["trades_with_pnl"]
+        pnl_sum = data["pnl_sum_quote"] if trades_with_pnl else None
+        fees_sum = data["fees_sum_quote"] if trades_with_pnl else None
+        entry_cost_sum = data["entry_cost_sum"]
+        roi_weighted = None
+        if trades_with_pnl and entry_cost_sum > 0:
+            roi_weighted = (data["pnl_sum_quote"] / entry_cost_sum) * 100.0
+        tp1_rate = (data["tp1_hits"] / trades_total * 100.0) if trades_total else None
+        tp2_rate = (data["tp2_hits"] / trades_total * 100.0) if trades_total else None
+
+        lines.append(
+            "| {month} | {trades_total} | {trades_with_pnl} | {pnl_sum} | {roi_weighted} | {fees_sum} | {tp1_rate} | {tp2_rate} |".format(
+                month=month,
+                trades_total=trades_total,
+                trades_with_pnl=trades_with_pnl,
+                pnl_sum=_format_number(pnl_sum),
+                roi_weighted=_format_number(roi_weighted),
+                fees_sum=_format_number(fees_sum),
+                tp1_rate=_format_number(tp1_rate),
+                tp2_rate=_format_number(tp2_rate),
+            )
+        )
+
+    lines.append("")
+    lines.append("## Trades Detail")
+    lines.append("")
+    lines.append("| date | symbol | side | qty_base_total | entry_price | avg_exit_price | fees_total_quote | pnl_quote | roi_pct | exit_type | tp1_hit | tp2_hit |")
+    lines.append("| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |")
+
+    def sort_key(rec: Dict[str, Any]) -> str:
+        closed_at = rec.get("closed_at")
+        dt = _parse_iso(closed_at) if closed_at else None
+        if dt:
+            return dt.isoformat()
+        date = rec.get("date")
+        if isinstance(date, str):
+            return date
+        return ""
+
+    for rec in sorted(records, key=sort_key):
+        date = _record_date(rec) or "N/A"
+        lines.append(
+            "| {date} | {symbol} | {side} | {qty} | {entry} | {avg_exit} | {fees} | {pnl} | {roi} | {exit_type} | {tp1} | {tp2} |".format(
+                date=date,
+                symbol=rec.get("symbol") or "N/A",
+                side=rec.get("side") or "N/A",
+                qty=_format_number(_safe_float(rec.get("qty_base_total"))),
+                entry=_format_number(_safe_float(rec.get("entry_price"))),
+                avg_exit=_format_number(_safe_float(rec.get("avg_exit_price"))),
+                fees=_format_number(_safe_float(rec.get("fees_total_quote"))),
+                pnl=_format_number(_safe_float(rec.get("pnl_quote"))),
+                roi=_format_number(_safe_float(rec.get("roi_pct"))),
+                exit_type=rec.get("exit_type") or "N/A",
+                tp1=_format_bool(rec.get("tp1_hit")),
+                tp2=_format_bool(rec.get("tp2_hit")),
+            )
+        )
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate manager report from enriched trade reports.")
+    parser.add_argument("--input", default=INPUT_PATH_DEFAULT)
+    parser.add_argument("--output", default=OUTPUT_PATH_DEFAULT)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    records, skipped = _read_jsonl(args.input)
+    summary = _summarize(records)
+    total_pnl_rows = sum(data["trades_with_pnl"] for data in summary.values())
+    total_pnl_sum = sum(data["pnl_sum_quote"] for data in summary.values()) if total_pnl_rows else None
+
+    if args.dry_run:
+        for month in sorted(summary.keys()):
+            data = summary[month]
+            print(
+                f"{month}: trades_total={data['trades_total']} trades_with_pnl={data['trades_with_pnl']} pnl_sum={_format_number(data['pnl_sum_quote'])}"
+            )
+    else:
+        content = _build_markdown(records, args.input)
+        _write_markdown(args.output, content)
+
+    print(f"input_records={len(records)}")
+    print(f"months_found={len(summary)}")
+    print(f"total_pnl_rows={total_pnl_rows}")
+    print(f"total_pnl_sum={_format_number(total_pnl_sum)}")
+    print(f"invalid_json_skipped={skipped}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Ensure fees aggregation follows the same eligibility as PnL so monthly fee totals only include rows with valid PnL, and present overall PnL total as `N/A` when there are no PnL rows.

### Description
- Updated `tools/make_manager_report.py` to only accumulate `fees_sum_quote` inside the `if pnl is not None:` branch in `_summarize` so fees are counted only for rows with eligible PnL.
- Changed monthly table fee display to `fees_sum = data["fees_sum_quote"] if trades_with_pnl else None` in `_build_markdown` so monthly fees show `N/A` when no PnL rows exist for the month.
- Set `total_pnl_sum = sum(...) if total_pnl_rows else None` in `main()` so overall PnL prints as `N/A` when `total_pnl_rows == 0`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cc8ec7218832386a35a098c453cd1)