### PR TITLE
Reduce log spam: one-time MANAGE_SKIP_OPENORDERS and guarded PRICE_SNAPSHOT_ERROR

### DIFF
--- a/executor_mod/price_snapshot.py
+++ b/executor_mod/price_snapshot.py
@@ -13,6 +13,7 @@ Pattern follows exchange_snapshot.py design (singleton, throttled refresh).
 
 from __future__ import annotations
 
+from contextlib import suppress
 import time
 from typing import Any, Callable, Dict, Optional
 
@@ -118,9 +119,6 @@ def refresh_price_snapshot(
         _snapshot.ok = True
         _snapshot.error = None
 
-        # Log successful refresh (optional, only if configured)
-        if _log_event_fn:
-            _log_event_fn("PRICE_SNAPSHOT_REFRESH", symbol=symbol, source=source, ok=True, price_mid=float(mid_price))
     except Exception as e:
         _snapshot.price_mid = 0.0
         _snapshot.ok = False
@@ -128,6 +126,7 @@ def refresh_price_snapshot(
 
         # Log failed refresh (optional, only if configured)
         if _log_event_fn:
-            _log_event_fn("PRICE_SNAPSHOT_REFRESH", symbol=symbol, source=source, ok=False, error=str(e))
+            with suppress(Exception):
+                _log_event_fn("PRICE_SNAPSHOT_ERROR", symbol=symbol, source=source, ok=False, error=str(e))
 
     return True


### PR DESCRIPTION
### Motivation
- Reduce per-tick log spam from the manager when a position is `OPEN_FILLED` by emitting `MANAGE_SKIP_OPENORDERS` only once per position.
- Prevent cascading failures from logging during price snapshot refreshes and avoid emitting successful-refresh events that are noisy (`PRICE_SNAPSHOT_REFRESH`).

### Description
- In `manage_v15_position` the code now resets the `openorders_skip_logged` flag when status returns to `OPEN` by calling `pos.pop("openorders_skip_logged", None)`.
- While in `OPEN_FILLED`, `MANAGE_SKIP_OPENORDERS` is logged only once per position by setting `pos["openorders_skip_logged"] = iso_utc()`, persisting via `st["position"]` and `save_state(st)`, and calling `log_event` only when the flag was not already set.
- In `executor_mod/price_snapshot.py` added `from contextlib import suppress` and removed the noisy successful `PRICE_SNAPSHOT_REFRESH` emission from `refresh_price_snapshot`.
- On refresh failure the module now emits `PRICE_SNAPSHOT_ERROR` guarded by `with suppress(Exception): _log_event_fn(...)` to avoid logging-related exceptions from affecting runtime.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d2945d4a48323aeef475f0e006139)