### PR TITLE
Persist SL/TP watchdog direct-price throttles across ticks

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -1554,6 +1554,9 @@ def manage_v15_position(symbol: str, st: Dict[str, Any]) -> None:
             next_direct_s = float(pos.get("sl_watchdog_direct_next_s") or 0.0)
             if now_s >= next_direct_s:
                 pos["sl_watchdog_direct_next_s"] = now_s + min_interval
+                # Persist throttle across ticks (state is reloaded every loop).
+                st["position"] = pos
+                _save_state_best_effort("sl_watchdog_direct_throttle")
                 with suppress(Exception):
                     price_now = float(binance_api.get_mid_price(symbol))
 
@@ -1802,6 +1805,9 @@ def manage_v15_position(symbol: str, st: Dict[str, Any]) -> None:
             next_direct_s = float(pos.get("tp_watchdog_direct_next_s") or 0.0)
             if now_s >= next_direct_s:
                 pos["tp_watchdog_direct_next_s"] = now_s + min_interval
+                # Persist throttle across ticks (state is reloaded every loop).
+                st["position"] = pos
+                _save_state_best_effort("tp_watchdog_direct_throttle")
                 with suppress(Exception):
                     price_now_tp = float(binance_api.get_mid_price(symbol))
 


### PR DESCRIPTION
### Motivation
- Ensure direct-price throttle timestamps (`sl_watchdog_direct_next_s` and `tp_watchdog_direct_next_s`) survive the per-loop state reload so the engine reliably throttles expensive direct mid-price calls and preserves intended watchdog behavior.

### Description
- After advancing the SL/TP watchdog direct-check timestamps the code now persists `pos` into `st["position"]` and calls `_save_state_best_effort` with `sl_watchdog_direct_throttle` and `tp_watchdog_direct_throttle` to save the throttle state across ticks.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696df42f6dd08323b63ff7a489b2bf2e)