### PR TITLE
Fail-close PnL when exit legs exist but none filled; harden tests for fee enrichment

### DIFF
--- a/test/test_enrich_trades_with_fees.py
+++ b/test/test_enrich_trades_with_fees.py
@@ -1,0 +1,101 @@
+import sys
+import types
+import unittest
+
+
+def _install_requests_failfast_stub() -> None:
+    """
+    Fail-fast stub for 'requests' so tests never accidentally hit the network.
+    If real 'requests' is installed, we leave it alone.
+    """
+    if "requests" in sys.modules:
+        return
+    mod = types.ModuleType("requests")
+
+    def _no_network(*args, **kwargs):
+        raise RuntimeError("Network access is disabled in unit tests (requests stub).")
+
+    class _Session:
+        def __init__(self, *a, **k):
+            raise RuntimeError("Network access is disabled in unit tests (requests stub).")
+
+    mod.get = _no_network
+    mod.post = _no_network
+    mod.request = _no_network
+    mod.Session = _Session
+    sys.modules["requests"] = mod
+
+
+def _notes_text(out: dict) -> str:
+    """
+    Normalize notes field(s) to text for robust asserts.
+    Supports string / list / tuple / set. Falls back to str(value).
+    """
+    val = out.get("reconciliation_notes", None)
+    if val is None:
+        val = out.get("notes", "")
+    if isinstance(val, (list, tuple, set)):
+        return " ".join(str(x) for x in val)
+    if isinstance(val, str):
+        return val
+    return str(val)
+
+
+_install_requests_failfast_stub()
+
+from tools import enrich_trades_with_fees
+
+
+class TestEnrichTradesWithFees(unittest.TestCase):
+    def test_blocks_pnl_when_all_exit_legs_unfilled(self):
+        rec = {
+            "symbol": "BTCUSDT",
+            "side": "LONG",
+            "entry_price": "100",
+            "qty_base_total": "1",
+            "exit_leg_orders": {
+                "tp1": {
+                    "orderId": 123,
+                    "executedQty": "0",
+                    "cummulativeQuoteQty": "0",
+                    "status": "NEW",
+                }
+            },
+        }
+
+        out = enrich_trades_with_fees._enrich_record(rec, cache={})
+
+        self.assertIsNone(out.get("pnl_quote"))
+        self.assertIsNone(out.get("roi_pct"))
+        self.assertIn("pnl_blocked_no_filled_exit", _notes_text(out))
+
+    def test_allows_pnl_when_exit_leg_filled(self):
+        rec = {
+            "symbol": "BTCUSDT",
+            "side": "LONG",
+            "entry_price": "100",
+            "qty_base_total": "1",
+            "exit_leg_orders": {
+                "tp1": {
+                    "orderId": 456,
+                    "executedQty": "1",
+                    "cummulativeQuoteQty": "120",
+                    "status": "FILLED",
+                }
+            },
+        }
+        cache = {
+            ("BTCUSDT", 456): [
+                {"commissionAsset": "USDT", "commission": "0.1"}
+            ]
+        }
+
+        out = enrich_trades_with_fees._enrich_record(rec, cache=cache)
+
+        self.assertIsNotNone(out.get("pnl_quote"))
+        self.assertIsNotNone(out.get("roi_pct"))
+        self.assertNotIn("pnl_blocked_no_filled_exit", _notes_text(out))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Prevent spurious PnL/ROI calculations when a record declares exit legs but none of those legs were actually filled by forcing a fail-closed enrichment path. 
- Make unit tests robust and network-safe by banning accidental HTTP usage during test collection and normalizing reconciliation notes for assertions. 

### Description

- In `tools/enrich_trades_with_fees.py` added a `filled_exit_legs` counter inside `_enrich_record`, incremented when `_leg_is_filled(leg_data)` is true, and early-return fail-closed when `had_leg` is true and `filled_exit_legs == 0` by setting `fees_total_quote`, `pnl_quote`, and `roi_pct` to `None` and appending the note `"pnl_blocked_no_filled_exit"`.
- In `_enrich_record` unfilled exit legs now get `leg_data["feeQuote"] = 0.0` and a note `"skip_fee_leg_<leg>_unfilled"`, while filled legs continue to fetch trades and compute fees as before.
- Tests were hardened in `test/test_enrich_trades_with_fees.py` by installing a fail-fast `requests` stub via `_install_requests_failfast_stub()` to prevent network access during tests and by adding `_notes_text(out)` to normalize `reconciliation_notes`/`notes` values for assertions.
- Kept existing fee aggregation and `_compute_exit_quote_total`/`_leg_is_filled` semantics unchanged except for the new blocking behavior when no exit legs were filled.

### Testing

- Ran `python -m pytest test/test_enrich_trades_with_fees.py` which collected and executed 2 tests and both passed. 
- The tests verify the negative case where exit legs exist but are unfilled results in `pnl_quote`/`roi_pct` being `None` and reconciliation notes containing `"pnl_blocked_no_filled_exit"`, and the positive case where an exit leg is filled allows PnL/ROI computation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e058a2e04832388aabfb32aa6c840)