### PR TITLE
Normalize margin borrow params to avoid Binance -1100 errors

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -109,7 +109,7 @@ ENV: Dict[str, Any] = {
 "STRICT_SOURCE": _get_bool("STRICT_SOURCE", True),
 
 # sizing
-"SYMBOL": os.getenv("SYMBOL", "BTCUSDC"),
+"SYMBOL": _get_str("SYMBOL", "BTCUSDC").strip().upper(),
 "QTY_USD": _get_float("QTY_USD", 100.0),
 "QTY_STEP": Decimal(os.getenv("QTY_STEP", "0.00001")),
 "MIN_QTY": Decimal(os.getenv("MIN_QTY", "0.00001")),

--- a/test/test_binance_api_smoke.py
+++ b/test/test_binance_api_smoke.py
@@ -1,4 +1,5 @@
 import unittest
+from decimal import Decimal
 from unittest.mock import patch, MagicMock
 
 # Import the module under test
@@ -60,6 +61,16 @@ class TestBinanceApiSmoke(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             binance_api.place_spot_market("BTCUSDC", "BUY", 0.001)
+
+    def test_fmt_amount_no_sci(self):
+        self.assertEqual(binance_api._fmt_amount_no_sci(1e-7), "0.0000001")
+        self.assertEqual(binance_api._fmt_amount_no_sci(Decimal("1E-8")), "0.00000001")
+        self.assertEqual(binance_api._fmt_amount_no_sci(" 0.0100 "), "0.01")
+        self.assertEqual(binance_api._fmt_amount_no_sci(Decimal("0E-8")), "0")
+        with self.assertRaises(ValueError):
+            binance_api._fmt_amount_no_sci(None)
+        with self.assertRaises(ValueError):
+            binance_api._fmt_amount_no_sci("abc")
 
     def test_place_order_raw_spot_endpoint_and_symbol_default(self):
         env = _spot_env()


### PR DESCRIPTION
### Motivation

- Prevent Binance 400 "-1100 Illegal characters found in a parameter" originating from margin pre-hook borrow/repay requests by removing scientific notation, whitespace and null-valued params from signed requests. 

### Description

- Add `_fmt_amount_no_sci` in `executor_mod/binance_api.py` to stringify numeric `amount` values without exponent notation, trim trailing zeros/dot, and reject invalid/None inputs. 
- Use `_fmt_amount_no_sci` in `margin_borrow()` and `margin_repay()` to replace `str(amount)` and normalize `asset`/`symbol` via `strip().upper()`. 
- In `_binance_signed_request()` strip all string params and drop any params with `None` before building the signed query string. 
- Normalize `SYMBOL` when loading environment in `executor.py` (`_get_str(...).strip().upper()`) and add unit tests for the formatter in `test/test_binance_api_smoke.py`.

### Testing

- Added unit test coverage for `_fmt_amount_no_sci` in `test/test_binance_api_smoke.py` to assert formatting of `1e-7`, `Decimal("1E-8")`, and string inputs and to assert errors on invalid inputs. 
- Ran `python -m pytest test/test_binance_api_smoke.py`; run aborted with `ModuleNotFoundError: No module named 'requests'` during test collection (environment missing `requests`), so full test suite could not complete. 
- Recommendation to re-run tests in CI or locally after installing test dependencies (e.g., `pip install -r requirements.txt` or `pip install requests`) and to perform an integration dry-run against testnet or `LIVE_VALIDATE_ONLY` mode to verify no -1100 occurs in margin pre-hook.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e4c0550cc8323915bbc83b42bf739)