### PR TITLE
Relax margin openOrders symbol restriction

### DIFF
--- a/test/test_binance_api_debug_logging.py
+++ b/test/test_binance_api_debug_logging.py
@@ -1,0 +1,68 @@
+import json
+import unittest
+from unittest.mock import patch, MagicMock
+
+import executor_mod.binance_api as binance_api
+
+
+def _reset_binance_api_globals():
+    binance_api._ENV = None
+    binance_api._BINANCE_TIME_OFFSET_MS = 0
+    binance_api._fmt_qty = None
+    binance_api._fmt_price = None
+    binance_api._round_qty = None
+
+
+def _spot_env(debug: bool = False):
+    return {
+        "BINANCE_API_KEY": "k",
+        "BINANCE_API_SECRET": "s",
+        "BINANCE_BASE_URL": "https://api.binance.test",
+        "RECV_WINDOW": 5000,
+        "SYMBOL": "BTCUSDC",
+        "TRADE_MODE": "spot",
+        "MARGIN_ISOLATED": "TRUE",
+        "MARGIN_SIDE_EFFECT": "NO_SIDE_EFFECT",
+        "MARGIN_AUTO_REPAY_AT_CANCEL": False,
+        "BINANCE_DEBUG_PARAMS": "1" if debug else "",
+    }
+
+
+class TestBinanceApiDebugLogging(unittest.TestCase):
+    def setUp(self):
+        _reset_binance_api_globals()
+
+    def test_logs_binance_req_fail_on_1100_when_debug_enabled(self):
+        binance_api.configure(_spot_env(debug=True))
+        response = MagicMock()
+        response.status_code = 400
+        response.text = json.dumps({"code": -1100, "msg": "Illegal characters found in a parameter."})
+
+        with patch.object(binance_api, "_do_request", return_value=response), \
+             patch.object(binance_api, "log_event") as log_event:
+            with self.assertRaises(RuntimeError):
+                binance_api._binance_signed_request("GET", "/api/v3/openOrders", {"symbol": "BTCUSDC"})
+
+            self.assertTrue(any(call.args and call.args[0] == "BINANCE_REQ_FAIL" for call in log_event.call_args_list))
+            for call in log_event.call_args_list:
+                if call.args and call.args[0] == "BINANCE_REQ_FAIL":
+                    payload = call.kwargs
+                    self.assertEqual(payload.get("endpoint"), "/api/v3/openOrders")
+                    self.assertEqual(payload.get("method"), "GET")
+                    params = payload.get("params") or {}
+                    self.assertNotIn("signature", params)
+                    self.assertNotIn("X-MBX-APIKEY", params)
+                    self.assertEqual(params.get("symbol"), "BTCUSDC")
+
+    def test_no_log_when_debug_disabled(self):
+        binance_api.configure(_spot_env(debug=False))
+        response = MagicMock()
+        response.status_code = 400
+        response.text = json.dumps({"code": -1100, "msg": "Illegal characters found in a parameter."})
+
+        with patch.object(binance_api, "_do_request", return_value=response), \
+             patch.object(binance_api, "log_event") as log_event:
+            with self.assertRaises(RuntimeError):
+                binance_api._binance_signed_request("GET", "/api/v3/openOrders", {"symbol": "BTCUSDC"})
+
+            self.assertFalse(any(call.args and call.args[0] == "BINANCE_REQ_FAIL" for call in log_event.call_args_list))

--- a/test/test_binance_api_smoke.py
+++ b/test/test_binance_api_smoke.py
@@ -133,6 +133,39 @@ class TestBinanceApiSmoke(unittest.TestCase):
             self.assertEqual(params["symbol"], "BTCUSDC")
             self.assertIn("isIsolated", params)
 
+    def test_open_orders_margin_cross_symbol_rules(self):
+        env = _margin_env()
+        env["MARGIN_ISOLATED"] = "FALSE"
+        binance_api.configure(env)
+
+        with patch.object(binance_api, "_binance_signed_request") as signed:
+            signed.return_value = []
+            binance_api.open_orders(None)
+            method, endpoint, params = signed.call_args[0]
+            self.assertEqual((method, endpoint), ("GET", "/sapi/v1/margin/openOrders"))
+            self.assertNotIn("symbol", params)
+
+        with patch.object(binance_api, "_binance_signed_request") as signed:
+            signed.return_value = []
+            binance_api.open_orders("")
+            method, endpoint, params = signed.call_args[0]
+            self.assertEqual((method, endpoint), ("GET", "/sapi/v1/margin/openOrders"))
+            self.assertNotIn("symbol", params)
+
+        with patch.object(binance_api, "_binance_signed_request") as signed:
+            signed.return_value = []
+            binance_api.open_orders(" BTCUSDC ")
+            method, endpoint, params = signed.call_args[0]
+            self.assertEqual((method, endpoint), ("GET", "/sapi/v1/margin/openOrders"))
+            self.assertEqual(params.get("symbol"), "BTCUSDC")
+
+        with patch.object(binance_api, "_binance_signed_request") as signed:
+            signed.return_value = []
+            binance_api.open_orders(" ethusdc ")
+            method, endpoint, params = signed.call_args[0]
+            self.assertEqual((method, endpoint), ("GET", "/sapi/v1/margin/openOrders"))
+            self.assertEqual(params.get("symbol"), "ETHUSDC")
+
     def test_check_and_cancel_order_endpoints(self):
         binance_api.configure(_spot_env())
         with patch.object(binance_api, "_binance_signed_request") as signed:


### PR DESCRIPTION
### Motivation
- Remove an overly strict cross-margin invariant that blocked normalized symbols other than `BTCUSDC` from being passed to the Binance `openOrders` signed endpoint.  
- This is a minimal hotfix to allow callers to provide any symbol (normalized) for margin open orders without changing existing behavior for spot.  
- Keep the previously added `BINANCE_REQ_FAIL` debug logging behavior unchanged.

### Description
- Removed the `ValueError` guard that enforced `symbol == "BTCUSDC"` when `MARGIN_ISOLATED` is not `TRUE`, and now pass any normalized symbol through to the margin `openOrders` params.  
- Preserve `symbol_norm = str(symbol or "").strip().upper()` and the omission of the `symbol` param when empty.  
- Updated unit test `test_open_orders_margin_cross_symbol_rules` in `test/test_binance_api_smoke.py` to assert that a normalized `ETHUSDC` is passed through in params instead of expecting a `ValueError`.

### Testing
- No automated tests were run as part of this change; modified tests are `test/test_binance_api_smoke.py` and the added debug logging test `test/test_binance_api_debug_logging.py` which can be executed with `pytest -q test/test_binance_api_smoke.py test/test_binance_api_debug_logging.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e628b16f8832391a3f33e8965a553)