### PR TITLE
Add BINANCE_DEBUG_PARAMS and BINANCE_DEBUG_BALANCE_MIN_SEC to executor ENV

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -138,6 +138,8 @@ ENV: Dict[str, Any] = {
 "BINANCE_BASE_URL": os.getenv("BINANCE_BASE_URL", "https://api.binance.com"),
 "BINANCE_API_KEY": os.getenv("BINANCE_API_KEY", ""),
 "BINANCE_API_SECRET": os.getenv("BINANCE_API_SECRET", ""),
+"BINANCE_DEBUG_PARAMS": _get_str("BINANCE_DEBUG_PARAMS", "0"),
+"BINANCE_DEBUG_BALANCE_MIN_SEC": _get_int("BINANCE_DEBUG_BALANCE_MIN_SEC", 30),
 
 # Trading account mode
 "TRADE_MODE": os.getenv("TRADE_MODE", "spot"),  # spot | margin


### PR DESCRIPTION
### Motivation
- Enable existing Binance debug gates by exposing `BINANCE_DEBUG_PARAMS` and `BINANCE_DEBUG_BALANCE_MIN_SEC` in the central `ENV` so debug behavior can be turned on via environment variables.

### Description
- Added `BINANCE_DEBUG_PARAMS` (string, default `"0"`) and `BINANCE_DEBUG_BALANCE_MIN_SEC` (int, default `30`) to the `ENV` dict in `executor.py` under the Binance section using existing helpers `_get_str` and `_get_int`.
- The same `ENV` dict is still passed into `binance_api.configure(ENV, ...)` elsewhere in `executor.py`, so no duplicate/missing copies were introduced.

### Testing
- No automated tests were run for this small change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e7e5a48e083238c06b0ecc873ad6b)