### PR TITLE
Fix margin borrow rounding and default debug flag

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -138,7 +138,7 @@ ENV: Dict[str, Any] = {
 "BINANCE_BASE_URL": os.getenv("BINANCE_BASE_URL", "https://api.binance.com"),
 "BINANCE_API_KEY": os.getenv("BINANCE_API_KEY", ""),
 "BINANCE_API_SECRET": os.getenv("BINANCE_API_SECRET", ""),
-"BINANCE_DEBUG_PARAMS": _get_str("BINANCE_DEBUG_PARAMS", "0"),
+"BINANCE_DEBUG_PARAMS": _get_str("BINANCE_DEBUG_PARAMS", "").strip(),
 "BINANCE_DEBUG_BALANCE_MIN_SEC": _get_int("BINANCE_DEBUG_BALANCE_MIN_SEC", 30),
 
 # Trading account mode


### PR DESCRIPTION
### Motivation
- Prevent passing float-artifact long-decimal strings to Binance margin borrow endpoints by switching borrow math to Decimal and applying correct step rounding rules.
- Avoid attempting quote-asset borrows when quote step sizes are unknown to prevent illegal-parameter (-1100) and downstream insufficient-balance (-2010) errors.
- Ensure BINANCE_DEBUG_PARAMS is falsy by default so debug/logging of Binance request params is off unless explicitly enabled.

### Description
- Rewrote borrow computation in `executor_mod/margin_policy.py` to use `Decimal` for `needed`, `free`, and `borrow_amt_dec`, and compute `borrow_amt_dec = max(needed - free, 0)`.
- Determined base/quote via `_split_symbol_assets(symbol)` and applied rounding rules: round down to explicit `stepSize` if present; if `stepSize` missing then use `QTY_STEP` (or BTC fallback `0.000001`) only for base-asset borrows and DO NOT use `QTY_STEP` for quote-asset borrows.
- If a quote-asset borrow lacks a known quote step size, skip the borrow, set `margin["last_borrow_skip_reason"] = "missing_quote_step_size"`, and emit a `BORROW_SKIP` event (using `api.log_event` when available); all logged numeric fields are emitted as strings to avoid float artifacts.
- Ensure the `BORROW_AMOUNT_ROUNDED` event logs the raw and rounded amounts as strings and call `api.margin_borrow` with the `Decimal` amount so the Binance layer can format it without scientific/float artifacts.
- Changed `executor.py` to set `"BINANCE_DEBUG_PARAMS": _get_str("BINANCE_DEBUG_PARAMS", "").strip()` so the default is an empty (falsy) string.
- Kept behavior identical except for borrow rounding/skip logic and debug default, and avoided adding new runtime dependencies or exposing secrets in logs.

### Testing
- Added/updated unit tests in `test/test_margin_policy.py` exercising: quote-asset skip when step size missing, base-asset fallback rounding when step missing, and preserved existing isolated-account flattening test; the test harness captures emitted log events via a `FakeApi`.
- Ran `pytest test/test_margin_policy.py` and all tests passed: `4 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e8f790d7c83238957f8d3ad1f6f34)