### PR TITLE
Round up margin borrows to avoid under-borrowing

### DIFF
--- a/test/test_margin_policy.py
+++ b/test/test_margin_policy.py
@@ -102,7 +102,27 @@ class TestMarginPolicy(unittest.TestCase):
         asset, amt, is_iso, sym = api.borrow_calls[0]
         self.assertEqual(asset, "BTC")
         self.assertIsInstance(amt, Decimal)
-        self.assertEqual(amt, Decimal("0.000291"))
+        self.assertEqual(amt, Decimal("0.000292"))
+
+    def test_borrow_rounds_up_to_step_size(self):
+        account = {"userAssets": [{"asset": "BTC", "free": "0.00103875"}]}
+        api = FakeApi(account)
+        st = {}
+        plan = {
+            "trade_key": "T2",
+            "is_isolated": False,
+            "borrow_asset": "BTC",
+            "borrow_amount": "0.00129",
+            "stepSize": "0.00001",
+        }
+
+        mp.ensure_borrow_if_needed(st, api, "BTCUSDC", "SELL", 0.00129, plan)
+
+        self.assertEqual(len(api.borrow_calls), 1)
+        asset, amt, is_iso, sym = api.borrow_calls[0]
+        self.assertEqual(asset, "BTC")
+        self.assertIsInstance(amt, Decimal)
+        self.assertEqual(amt, Decimal("0.00026"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation

- Prevent under-borrowing in margin SELL flows where borrow is rounded down to the asset step size and causes Binance -2010 "insufficient balance" errors.

### Description

- Add helper `_round_amount_up(amount: Decimal, step: Decimal) -> Decimal` and import `ROUND_UP` from `decimal` to support ceiling rounding.
- Replace rounding-down logic with ceiling rounding for primary `stepSize` and base-asset fallback (`QTY_STEP` and BTC fallback) so borrowed + free >= needed.
- Preserve behavior for quote-asset when step size is missing by skipping borrow and logging `BORROW_SKIP` with `missing_quote_step_size`.
- Update state bookkeeping and logging to continue using `api.log_event` (or fallback import) and pass Decimal to `api.margin_borrow` unchanged.
- Update tests in `test/test_margin_policy.py` to expect rounding-up behavior and add a new test reproducing the under-borrow scenario (asserts borrow Decimal("0.00026") for the example inputs).

### Testing

- Ran the full test suite with `python -m unittest -q`; the run failed with unrelated import errors due to missing environment packages (`requests` and `pandas`) causing 8 import errors and `FAILED (errors=8)`.
- Changes are limited to `executor_mod/margin_policy.py` and `test/test_margin_policy.py` and the updated/added margin-policy tests were exercised in local targeted testing (see CI recommendation); full repo tests require optional deps installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e9b6b0d808323afbcbad316e0d2d1)