### PR TITLE
Pass through asset/quote step env keys into executor ENV

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -114,6 +114,11 @@ ENV: Dict[str, Any] = {
 "QTY_STEP": Decimal(os.getenv("QTY_STEP", "0.00001")),
 "MIN_QTY": Decimal(os.getenv("MIN_QTY", "0.00001")),
 "MIN_NOTIONAL": _get_float("MIN_NOTIONAL", 5.0),
+"ASSET_STEP_SIZE_USDC": os.getenv("ASSET_STEP_SIZE_USDC"),
+"ASSET_STEP_SIZES": os.getenv("ASSET_STEP_SIZES"),
+"QUOTE_STEP": os.getenv("QUOTE_STEP"),
+"QUOTE_ASSET_STEP": os.getenv("QUOTE_ASSET_STEP"),
+"QUOTE_STEP_SIZE": os.getenv("QUOTE_STEP_SIZE"),
 
 # price formatting
 "TICK_SIZE": Decimal(os.getenv("TICK_SIZE", "0.01")),


### PR DESCRIPTION
### Motivation
- `ENV` is constructed explicitly in `executor.py` and then passed into `binance_api.configure(ENV, ...)`, so `api._env()` only sees keys present in that `ENV` and not raw `os.environ` entries.
- Because `ASSET_STEP_SIZE_USDC` (and related keys) were not included in that `ENV` dict, values set in the Docker environment did not reach `margin_policy` via `api._env()`.

### Description
- Added pass-through entries to the executor `ENV` for `ASSET_STEP_SIZE_USDC`, `ASSET_STEP_SIZES`, `QUOTE_STEP`, `QUOTE_ASSET_STEP`, and `QUOTE_STEP_SIZE` in `executor.py` without adding parsing or defaults so the values flow to `binance_api` and `margin_policy` via `ENV`.
- No other logic, parsing, or defaults were introduced and the rest of the runtime behavior is unchanged when these variables are not set.

### Testing
- No automated tests were run for this config-only change (manual/config validation expected); change is limited to passing environment values through and should be validated by setting `ASSET_STEP_SIZE_USDC` in the Docker env and confirming `margin_policy._asset_step_size(..., asset="USDC", symbol="BTCUSDC")` returns the expected value.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f7e6c7800832396735c9724098a14)