### PR TITLE
Assert no BE SL placement before cancel confirmation

### DIFF
--- a/test/test_executor.py
+++ b/test/test_executor.py
@@ -255,6 +255,7 @@ class TestExecutorV15(unittest.TestCase):
                 patch.object(executor, "send_webhook", lambda *_: None), \
                 patch.object(executor, "log_event", lambda *_ , **__: None):
                 executor.manage_v15_position(executor.ENV["SYMBOL"], st)
+                self.assertEqual(m_place.call_count, 0)
                 executor.manage_v15_position(executor.ENV["SYMBOL"], st)
         finally:
             executor.ENV["SL_WATCHDOG_RETRY_SEC"] = prev_retry


### PR DESCRIPTION
### Motivation
- Ensure BE (break-even) stop-loss placement is deferred until the exchange cancel confirmation in the tp1 test scenario in `test/test_executor.py`.

### Description
- Add an assertion that `place_order_raw` has not been called on the first tick before cancel confirmation by checking `m_place.call_count == 0` between two calls to `manage_v15_position` in `test/test_executor.py`.

### Testing
- No automated tests were executed for this change; run `pytest test/test_executor.py::TestExecutorV15::test_tp1_be_cancel_first_then_place` to verify the updated test locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69714ba0b8308323ad526adaee00b1eb)