### PR TITLE
Gate TP2 synthetic trailing with price checks and SL-cancel gating

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -2214,8 +2214,71 @@ def manage_v15_position(symbol: str, st: Dict[str, Any]) -> None:
             }
             log_event(action, mode="live", **{k: v for k, v in dust_payload.items() if v is not None})
 
+        # Handle TP2 missing gate failures (fail-loud, no state changes besides dedup flag)
+        elif action in ("TP2_MISSING_NOT_IN_ZONE", "TP2_MISSING_GATE_UNCERTAIN"):
+            tp2_status = tp_plan.get("tp2_status")
+            price_now = tp_plan.get("price_now")
+            tp2_price = tp_plan.get("tp2_price")
+            dedup_key = "tp2_missing_not_in_zone_notified" if action == "TP2_MISSING_NOT_IN_ZONE" else "tp2_missing_gate_uncertain_notified"
+            if not pos.get(dedup_key):
+                pos[dedup_key] = iso_utc()
+                st["position"] = pos
+                save_state(st)
+            payload = {k: v for k, v in {"tp2_status": tp2_status, "price_now": price_now, "tp2_price": tp2_price}.items() if v is not None}
+            log_event(action, mode="live", **payload)
+            send_webhook({"event": action, "mode": "live", "symbol": symbol, **payload})
+            return
+
         # Handle ACTIVATE_SYNTHETIC_TRAILING
         elif action == "ACTIVATE_SYNTHETIC_TRAILING":
+            tp2_status = tp_plan.get("tp2_status")
+            price_now = tp_plan.get("price_now")
+            tp2_price = tp_plan.get("tp2_price")
+            require_price_gate = bool(tp_plan.get("require_price_gate", True))
+            if require_price_gate:
+                gate_ok = False
+                try:
+                    price_now_f = float(price_now)
+                    tp2_price_f = float(tp2_price)
+                except (TypeError, ValueError):
+                    gate_ok = False
+                else:
+                    if math.isfinite(price_now_f) and math.isfinite(tp2_price_f) and tp2_price_f > 0.0:
+                        if pos.get("side") == "LONG":
+                            gate_ok = price_now_f >= tp2_price_f
+                        elif pos.get("side") == "SHORT":
+                            gate_ok = price_now_f <= tp2_price_f
+                if not gate_ok:
+                    payload = {k: v for k, v in {"tp2_status": tp2_status, "price_now": price_now, "tp2_price": tp2_price}.items() if v is not None}
+                    log_event("TP2_MISSING_GATE_REJECTED", mode="live", **payload)
+                    send_webhook({"event": "TP2_MISSING_GATE_REJECTED", "mode": "live", "symbol": symbol, **payload})
+                    return
+
+            pend_sl = int(pos.get("trail_pending_cancel_sl") or 0)
+            if pend_sl:
+                od_p = None
+                with suppress(Exception):
+                    od_p = binance_api.check_order_status(symbol, pend_sl)
+                st_p = str((od_p or {}).get("status", "")).upper()
+                if st_p == "FILLED":
+                    _finalize_close("SL")
+                    return
+                if st_p not in ("CANCELED", "REJECTED", "EXPIRED"):
+                    return
+                pos["trail_pending_cancel_sl"] = 0
+                pos.setdefault("orders", {})["sl"] = 0
+                st["position"] = pos
+                save_state(st)
+
+            sl_id = int((pos.get("orders") or {}).get("sl") or 0)
+            if sl_id:
+                _cancel_ignore_unknown(sl_id)
+                pos["trail_pending_cancel_sl"] = sl_id
+                st["position"] = pos
+                save_state(st)
+                log_event("TP2_SYNTHETIC_TRAIL_CANCEL_SL", mode="live", order_id_sl=sl_id)
+                return
+
             if tp_plan.get("set_tp2_synthetic"):
                 pos["tp2_synthetic"] = True
             if tp_plan.get("activate_trail"):


### PR DESCRIPTION
### Motivation
- Prevent synthetic trailing activation unless TP2 price is known and the market price has actually crossed TP2, and ensure SL is cancelled first to avoid conflicting protective orders.

### Description
- Update `executor_mod/exit_safety.py` to gate TP2-missing logic: fetch `tp2_price` via `_tp_price`, return `TP2_MISSING_GATE_UNCERTAIN` when price is unknown, return `TP2_MISSING_NOT_IN_ZONE` when price did not cross, and only return `ACTIVATE_SYNTHETIC_TRAILING` when the gate is satisfied; include `tp2_status`, `price_now`, `tp2_price`, and `require_price_gate=True` and set `trail_qty = qty2 + qty3` in the plan.
- Update `executor.py` to handle the new actions `TP2_MISSING_NOT_IN_ZONE` and `TP2_MISSING_GATE_UNCERTAIN` by logging, sending a webhook, and setting a dedup flag on the position to avoid spamming notifications; enforce the price gate on `ACTIVATE_SYNTHETIC_TRAILING`, require cancelling existing SL first (set `trail_pending_cancel_sl` and save state), wait for cancel confirmation (or finalize close if SL filled), and only then set `tp2_synthetic`, `trail_active` and `trail_qty`.
- Extend tests in `test/test_tp_watchdog.py` to add `test_tp2_missing_gate_not_crossed_returns_not_in_zone` and adjust the TP2 missing activation test to assert the gate metadata (`require_price_gate`, `tp2_status`, `tp2_price`, `price_now`) and exercise both not-in-zone and crossed scenarios.

### Testing
- Ran the full test suite with `python -m unittest discover -s test -t . -v`; the run executed 99 tests and completed with errors due to missing external test dependencies (`pandas`, `requests`) in the environment, producing `FAILED (errors=9)`; the TP watchdog tests (including the newly added/modified TP2 gate tests) executed and passed within the test output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697605467b5883239365a25a7068aa65)