### PR TITLE
Add VWAP distance cap for PEAK emission in DeltaScout

### DIFF
--- a/deltascout/.env.example
+++ b/deltascout/.env.example
@@ -9,6 +9,7 @@ TIER_B_IMB_MIN=
 AVG9_MAX=
 CHOP30_MAX=
 COH10_MIN=
+VWAP_MAX_DIST_USD=1000
 
 # Paths (safe defaults allowed, but you can override)
 FILE_PATH=/data/feed/aggregated.csv

--- a/deltascout/delta_scout.py
+++ b/deltascout/delta_scout.py
@@ -36,6 +36,7 @@ AVG9_MAX        = float(os.getenv("AVG9_MAX", "1"))
 PRINT_EVERY     = int(os.getenv("PRINT_EVERY", "1"))
 STARTUP_LOOKBACK_MIN = int(os.getenv("STARTUP_LOOKBACK_MIN", "180"))
 CHOP30_MAX = float(os.getenv("CHOP30_MAX", "2.6"))
+VWAP_MAX_DIST_USD = float(os.getenv("VWAP_MAX_DIST_USD", "1000"))
 
 COH10_MIN  = float(os.getenv("COH10_MIN", "0.30"))
 IMB_MIN    = float(os.getenv("IMB_MIN", "0.55"))
@@ -62,6 +63,7 @@ ENV = {
     "AGG_CSV": FILE_PATH,
     "ROLL_WINDOW_MIN": ROLL_WINDOW_MIN,
     "VWAP_WINDOW_MIN": VWAP_WINDOW_MIN,
+    "VWAP_MAX_DIST_USD": VWAP_MAX_DIST_USD,
     "POC_STEP_USD": POC_STEP_USD,
     "ZERO_QTY_TH": ZERO_QTY_TH,
     "AVG9_MAX": AVG9_MAX,
@@ -458,6 +460,10 @@ class Scout:
                 self.prev_peak = curr; return
             if vwap_now is not None and curr["price"] < vwap_now:
                 self.prev_peak = curr; return
+            if vwap_now is not None:
+                vwap_f = float(vwap_now)
+                if (price_now - vwap_f) > VWAP_MAX_DIST_USD:
+                    self.prev_peak = curr; return
             if not prev_pass_3of3(curr, self.prev_peak):
                 self.prev_peak = curr; return
 
@@ -516,6 +522,10 @@ class Scout:
                 self.prev_peak = curr; return
             if vwap_now is not None and curr["price"] > vwap_now:
                 self.prev_peak = curr; return
+            if vwap_now is not None:
+                vwap_f = float(vwap_now)
+                if (vwap_f - price_now) > VWAP_MAX_DIST_USD:
+                    self.prev_peak = curr; return
             if not prev_pass_3of3(curr, self.prev_peak):
                 self.prev_peak = curr; return
 


### PR DESCRIPTION
### Motivation
- Prevent emitting `PEAK` events when the current price is too far from VWAP in the allowed direction to reduce false signals.
- This is an additional gate on top of the existing "price must be on the correct side of VWAP" rule and must not change baseline updates.

### Description
- Add environment variable `VWAP_MAX_DIST_USD` (default `1000`) and expose it in the module `ENV` and `deltascout/.env.example`.
- In the MAX (long) peak branch insert a directional cap that casts `vwap_now` to `vwap_f` and returns (without emitting) if `(price_now - vwap_f) > VWAP_MAX_DIST_USD` while preserving `self.prev_peak` updates.
- In the MIN (short) peak branch insert the symmetric directional cap that returns if `(vwap_f - price_now) > VWAP_MAX_DIST_USD` while preserving `self.prev_peak` updates.
- Keep existing checks (VWAP side, `prev_pass_3of3`, EMA50/CHOP/COH/IMB) and emit logic unchanged except for the added distance gate.

### Testing
- No automated tests were executed for this change (no test harness run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69765b10c8448323901ca1a19304740b)