### PR TITLE
Add PRE/POST assertions for TP2 synthetic trailing Phase B cleanup in tests

### DIFF
--- a/test/test_executor.py
+++ b/test/test_executor.py
@@ -267,6 +267,9 @@ class TestExecutorV15(unittest.TestCase):
             if int(oid) in (222, 333):
                 return {"status": "CANCELED"}
             return {"status": "CANCELED"}
+        self.assertEqual(st["position"].get("trail_pending_cancel_tp2"), 222)
+        self.assertEqual(st["position"].get("trail_pending_cancel_sl"), 333)
+        self.assertEqual(st["position"].get("trail_cancel_next_s"), 1000.0)
         with patch.object(executor, "_now_s", return_value=1011.0), \
             patch.object(executor.binance_api, "open_orders", return_value=[]), \
             patch.object(executor.binance_api, "check_order_status", side_effect=_fake_status), \
@@ -283,6 +286,8 @@ class TestExecutorV15(unittest.TestCase):
         self.assertTrue(st["position"].get("tp2_synthetic"))
         self.assertIsNone(st["position"].get("trail_pending_cancel_tp2"))
         self.assertIsNone(st["position"].get("trail_pending_cancel_sl"))
+        self.assertIsNone(st["position"].get("trail_cancel_next_s"))
+        self.assertIsNone(st["position"].get("trail_qty_safe"))
 
     def test_tp2_synthetic_trailing_waits_for_sl_cancel(self):
         st = {
@@ -377,6 +382,10 @@ class TestExecutorV15(unittest.TestCase):
 
         self.assertTrue(st["position"].get("trail_active"))
         self.assertEqual(st["position"].get("trail_qty"), 0.05)
+        self.assertIsNone(st["position"].get("trail_qty_safe"))
+        self.assertIsNone(st["position"].get("trail_pending_cancel_tp2"))
+        self.assertIsNone(st["position"].get("trail_pending_cancel_sl"))
+        self.assertIsNone(st["position"].get("trail_cancel_next_s"))
 
     def test_tp2_synthetic_trailing_recomputes_missing_trail_qty_safe(self):
         st = {
@@ -409,6 +418,10 @@ class TestExecutorV15(unittest.TestCase):
             if int(oid) in (222, 333):
                 return {"status": "CANCELED"}
             return {"status": "CANCELED"}
+        self.assertEqual(st["position"].get("trail_pending_cancel_tp2"), 222)
+        self.assertEqual(st["position"].get("trail_pending_cancel_sl"), 333)
+        self.assertEqual(st["position"].get("trail_cancel_next_s"), 1000.0)
+        self.assertIsNone(st["position"].get("trail_qty_safe"))
 
         with patch.object(executor, "_now_s", return_value=1011.0), \
             patch.object(executor.binance_api, "open_orders", return_value=[]), \


### PR DESCRIPTION
### Motivation
- Make TP2 synthetic trailing success-path tests prove Phase B cleanup actually runs by asserting pending cancel flags/timer are present before the manage tick and cleared after a successful activation. 
- Align test expectations with executor behavior for `trail_qty_safe` based on actual Phase B code that pops `trail_qty_safe` on activation. 

### Description
- Added PRE assertions in success-path tests to assert `trail_pending_cancel_tp2`, `trail_pending_cancel_sl`, and `trail_cancel_next_s` are present before calling `manage_v15_position` in `test/test_executor.py`. 
- Added POST assertions to confirm `trail_pending_cancel_tp2`, `trail_pending_cancel_sl`, `trail_cancel_next_s` and `trail_qty_safe` are cleared after successful synthetic trailing activation in the three targeted TP2 tests. 
- Confirmed executor Phase B contains `pos.pop("trail_qty_safe", None)`, so tests assert `trail_qty_safe` is cleared on success.

### Testing
- Ran targeted pytest: `pytest -q test/test_executor.py -k "tp2_synthetic_trailing_phase_b_confirms_and_activates or tp2_synthetic_trailing_clamps_trail_qty_to_remaining or tp2_synthetic_trailing_recomputes_missing_trail_qty_safe"`. 
- Test run failed during collection with `ModuleNotFoundError: No module named 'pandas'`, so the new assertions were not executed in this environment. 
- Only `test/test_executor.py` was modified. Please run the same pytest command in an environment with test dependencies installed to validate the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69776becd10c832385f7a176ed36e5a1)