### PR TITLE
Block watchdogs during exit cleanup wait

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -1323,7 +1323,8 @@ def manage_v15_position(symbol: str, st: Dict[str, Any]) -> None:
                     next_cleanup_s=next_cleanup,
                     wait_sec=max(0.0, next_cleanup - now_s),
                 )
-            # Do not return: allow SL/TP reconciliation while cleanup is throttled.
+            # Skip SL/TP/watchdog actions while cleanup is throttled.
+            return
         if now_s >= next_cleanup:
             retry_ids = pos.get("exit_cleanup_order_ids") or []
             failed_ids: List[int] = []


### PR DESCRIPTION
### Motivation
- Prevent SL/TP/watchdog logic from re-entering while an exit cleanup is throttled to avoid sending a `MARKET_FLATTEN` after `exit_cleanup_pending` is set, which could open an unintended reverse position if the exchange is already flat but the in-memory `pos` remains `OPEN`.

### Description
- Short-circuit `manage_v15_position` in `executor.py` by returning early when `pos.get("exit_cleanup_pending")` is true and `now_s < next_cleanup`, and update the comment to reflect the guard; the retry/cleanup path when `now_s >= next_cleanup` is unchanged.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977c8d751948323b7e512749533e0e8)