### PR TITLE
Rate-limit SL_STATUS_POLL logs (emit only on change or heartbeat)

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -2617,13 +2617,21 @@ def manage_v15_position(symbol: str, st: Dict[str, Any]) -> None:
             sl_status = ""
             if isinstance(sl_status_payload, dict):
                 sl_status = str(sl_status_payload.get("status", "")).upper()
-            log_event(
-                "SL_STATUS_POLL",
-                mode="live",
-                order_id_sl=sl_id2,
-                source=sl_status_source,
-                status=sl_status or "UNKNOWN",
-            )
+            log_every_s = float(ENV.get("SL_STATUS_POLL_LOG_EVERY_SEC") or 60.0)
+            status_norm = sl_status or "UNKNOWN"
+            last_status = str(pos.get("sl_status_last_log") or "")
+            log_next_s = float(pos.get("sl_status_log_next_s") or 0.0)
+            should_log = (status_norm != last_status) or (now_s >= log_next_s)
+            if should_log:
+                pos["sl_status_last_log"] = status_norm
+                pos["sl_status_log_next_s"] = now_s + log_every_s
+                log_event(
+                    "SL_STATUS_POLL",
+                    mode="live",
+                    order_id_sl=sl_id2,
+                    source=sl_status_source,
+                    status=status_norm,
+                )
             sl_filled = sl_status == "FILLED" if sl_status else _status_is_filled(sl_id2)
 
             if sl_filled:


### PR DESCRIPTION
### Motivation
- `SL_STATUS_POLL` was being emitted from `executor.py` on every status poll and included fields `mode`, `order_id_sl`, `source`, and `status`, which produced frequent identical lines at the poll cadence and clogged `executor.log`.
- The goal is to remove log spam while keeping the polling/check logic, poll frequency, and all trading actions (MARKET/Cancel/Replace/watchdogs/invariants) unchanged.
- The change must be restart-safe and local to the area around the existing `STATUS_POLL` logging (near the `SL` polling block in `executor.py`).

### Description
- Added a small rate-limit/heartbeat around the existing `SL_STATUS_POLL` logging: logs are now emitted only when the `status` value changes or when a heartbeat interval elapses as defined by `SL_STATUS_POLL_LOG_EVERY_SEC` (ENV, default `60.0`).
- Persisted restart-safe state under the position (`pos`) using keys `sl_status_last_log` and `sl_status_log_next_s` to track the last-logged status and next allowed log time without changing trading state or behavior.
- The polling cadence and SL handling remain unchanged: `pos["sl_status_next_s"]` and `LIVE_STATUS_POLL_EVERY` are left intact and the subsequent `sl_filled` detection and close flow are unmodified.
- To verify behavior locally, `grep -n "SL_STATUS_POLL" /data/logs/executor.log` before/after or inspect the code around the poll with `rg -n "SL_STATUS_POLL" executor.py`.

### Testing
- Ran `python -m pytest test/ -q` which failed during collection due to missing external test dependencies (`requests` and `pandas`) so automated tests could not complete; no test failures related to the patch itself were observed because test collection stopped early.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977fdd052f083238d80d0b82168a09d)