### PR TITLE
SL_STATUS_POLL: log only on status change using single state key

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -2617,14 +2617,12 @@ def manage_v15_position(symbol: str, st: Dict[str, Any]) -> None:
             sl_status = ""
             if isinstance(sl_status_payload, dict):
                 sl_status = str(sl_status_payload.get("status", "")).upper()
-            log_every_s = float(ENV.get("SL_STATUS_POLL_LOG_EVERY_SEC") or 60.0)
             status_norm = sl_status or "UNKNOWN"
-            last_status = str(pos.get("sl_status_last_log") or "")
-            log_next_s = float(pos.get("sl_status_log_next_s") or 0.0)
-            should_log = (status_norm != last_status) or (now_s >= log_next_s)
-            if should_log:
-                pos["sl_status_last_log"] = status_norm
-                pos["sl_status_log_next_s"] = now_s + log_every_s
+            last_status = str(pos.get("sl_last_status_logged") or "")
+            if status_norm != last_status:
+                pos["sl_last_status_logged"] = status_norm
+                st["position"] = pos
+                _save_state_best_effort("sl_status_change")
                 log_event(
                     "SL_STATUS_POLL",
                     mode="live",


### PR DESCRIPTION
### Motivation
- Eliminate SL_STATUS_POLL log spam by emitting the event only when the normalized SL status actually changes, including the first-observed state.
- Remove heartbeat/timer-driven periodic logging and the multiple per-source state keys that caused duplicate logs.
- Preserve all trading/finalization logic and avoid blocking I/O on the manage tick by using best-effort state persistence.

### Description
- Replaced the previous heartbeat/timer logic with a single `pos["sl_last_status_logged"]` comparison against `status_norm` and only emit `SL_STATUS_POLL` when the value differs.
- Persist the last-logged status with `_save_state_best_effort("sl_status_change")` when a change occurs, and update `st["position"]` accordingly.
- Removed use of `SL_STATUS_POLL_LOG_EVERY_SEC`, `*_log_next_s`, and keys such as `sl_status_last_log` / `oo_sl_last_status` in the changed code path.
- Added unit test `test_sl_status_poll_logs_only_on_change_open_orders` in `test/test_executor.py` that asserts repeated `NEW` polls log once and a subsequent `NEW -> FILLED` transition logs once.

### Testing
- Added the unit test `test_sl_status_poll_logs_only_on_change_open_orders` to `test/test_executor.py` as the verification for the new behavior.
- Executed `python -m pytest test/ -q`, but test collection failed with `ModuleNotFoundError` for required external packages (`pandas`, `requests`), so automated tests could not complete in this environment.
- Recommend running `python -m pytest test/test_executor.py -k sl_status_poll_logs_only_on_change_open_orders -q` in an environment with dependencies installed to confirm the behavior (expected logs: `NEW` once, then `FILLED` once).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697803775d08832390bbc5ff0dafb77c)