### PR TITLE
Persist SL status change logs

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -2617,14 +2617,15 @@ def manage_v15_position(symbol: str, st: Dict[str, Any]) -> None:
             sl_status = ""
             if isinstance(sl_status_payload, dict):
                 sl_status = str(sl_status_payload.get("status", "")).upper()
-            log_every_s = float(ENV.get("SL_STATUS_POLL_LOG_EVERY_SEC") or 60.0)
             status_norm = sl_status or "UNKNOWN"
-            last_status = str(pos.get("sl_status_last_log") or "")
-            log_next_s = float(pos.get("sl_status_log_next_s") or 0.0)
-            should_log = (status_norm != last_status) or (now_s >= log_next_s)
-            if should_log:
-                pos["sl_status_last_log"] = status_norm
-                pos["sl_status_log_next_s"] = now_s + log_every_s
+            last_status = str(pos.get("sl_last_status_logged") or "")
+            if status_norm != last_status:
+                pos["sl_last_status_logged"] = status_norm
+                st["position"] = pos
+                try:
+                    save_state(st)   # best-effort, не ламає цикл
+                except Exception:
+                    pass
                 log_event(
                     "SL_STATUS_POLL",
                     mode="live",


### PR DESCRIPTION
### Motivation
- Reduce noisy periodic SL status logs and ensure SL status transitions are persisted so state can be used for reconciliation and recovery.

### Description
- Update `executor.py` SL polling to log `SL_STATUS_POLL` only when the normalized SL status changes and store the last seen status in `pos["sl_last_status_logged"]` instead of time-gated logging fields.
- Persist the modified position into `st` and call `save_state(st)` in a best-effort `try/except` (so failures won't break the polling loop), and keep existing `SL_FILLED` handling unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69781e636e348323b9980a583cc7071e)