### PR TITLE
Remove unused _round_amount_down helper from margin_policy.py

### DIFF
--- a/executor_mod/margin_policy.py
+++ b/executor_mod/margin_policy.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import json
-from decimal import Decimal, ROUND_DOWN, ROUND_UP
+from decimal import Decimal, ROUND_UP
 from typing import Any, Dict, Optional
 
 
@@ -125,13 +125,6 @@ def _asset_step_size(plan: Dict[str, Any], api: Any, asset: str, symbol: str) ->
                 return _to_decimal(env.get(key))
     return None
 
-
-def _round_amount_down(amount: Decimal, step_size: Decimal) -> Decimal:
-    step_d = _to_decimal(step_size)
-    if step_d is None or step_d <= 0:
-        return Decimal(str(amount))
-    units = (Decimal(str(amount)) / step_d).to_integral_value(rounding=ROUND_DOWN)
-    return units * step_d
 
 
 def _round_amount_up(amount: Decimal, step_size: Decimal) -> Decimal:


### PR DESCRIPTION
### Motivation
- Remove a dead private helper that had no non-definition usages to reduce dead code and unused imports.

### Description
- Deleted the `_round_amount_down` function from `executor_mod/margin_policy.py` and removed the now-unused `ROUND_DOWN` import, leaving `ROUND_UP` only.

### Testing
- Ran the requested static checks: `rg -n "(?<!def )\b_round_amount_down\b" -S --pcre2 executor.py executor_mod tools test` -> no matches; `rg -n "\bROUND_DOWN\b" executor_mod/margin_policy.py` after the change -> no matches; commit recorded successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978a3cb77c48323b6fcc95162435ea0)