### PR TITLE
Document pytest-only testing and add dev requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,8 +437,8 @@ bootstrap_seen_keys_from_tail(st, tail_lines)
 
 **Запуск тестів**:
 ```bash
-python -m unittest -q
-python -m pytest test/test_tp_watchdog.py -v
+pytest -q
+pytest -q test/test_tp_watchdog.py
 ```
 
 **Важливо для тестів**: `exchange_snapshot` є singleton модулем, який може зберігати стан між тестами. У `test_tp_watchdog.py` використовується `reset_snapshot_for_tests()` в `setUp()` для ізоляції тестів. Ця функція призначена ТІЛЬКИ для тестів і НЕ має використовуватися в production runtime.
@@ -1308,38 +1308,46 @@ python executor.py
 ## Тестування
 
 ```bash
+# Тести запускаються лише через pytest.
+# python -m unittest не підтримується, бо тести використовують pytest-фічі/імпорти.
+
+# Встановити залежності
+pip install -r requirements.txt
+pip install -r requirements-dev.txt
+
 # Запустити всі тести
-python -m pytest test/
+pytest -q
 
 # Окремі модулі
-python -m pytest test/test_executor.py
-python -m pytest test/test_state_store.py
-python -m pytest test/test_binance_api_smoke.py
-python -m pytest test/test_invariants_module.py
-python -m pytest test/test_margin_policy.py
-python -m pytest test/test_margin_policy_isolated.py
-python -m pytest test/test_trail.py
+pytest -q test/test_executor.py
+pytest -q test/test_state_store.py
+pytest -q test/test_binance_api_smoke.py
+pytest -q test/test_invariants_module.py
+pytest -q test/test_margin_policy.py
+pytest -q test/test_margin_policy_isolated.py
+pytest -q test/test_trail.py
 
 # Watchdog тести
-python -m pytest test/test_tp_watchdog.py -v
-python -m pytest test/test_sl_watchdog.py -v
+pytest -q test/test_tp_watchdog.py
+pytest -q test/test_sl_watchdog.py
 
 # Snapshot тести
-python -m pytest test/test_exchange_snapshot.py
-python -m pytest test/test_price_snapshot.py
+pytest -q test/test_exchange_snapshot.py
+pytest -q test/test_price_snapshot.py
 
 # Інші функціональні тести
-python -m pytest test/test_market_data.py
-python -m pytest test/test_event_dedup.py
-python -m pytest test/test_risk_math.py
-python -m pytest test/test_notifications.py
-python -m pytest test/test_enrich_trades_with_fees.py
+pytest -q test/test_market_data.py
+pytest -q test/test_event_dedup.py
+pytest -q test/test_risk_math.py
+pytest -q test/test_notifications.py
+pytest -q test/test_enrich_trades_with_fees.py
 
 # Запуск з verbose output
-python -m pytest -v test/
+pytest -v test/
 
 # Запуск з print statements
-python -m pytest -s test/test_executor.py
+pytest -s test/test_executor.py
+
 ```
 
 ---

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest
+pandas
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pandas
+requests


### PR DESCRIPTION
### Motivation
- Make test usage explicit and reproducible by standardizing on `pytest` and ensuring dev/test dependencies are captured so `pytest -q` can be run in a fresh environment.

### Description
- Add `requirements.txt` listing runtime packages required by the code (`pandas`, `requests`).
- Add `requirements-dev.txt` listing test/dev dependencies (`pytest`, `pandas`, `requests`).
- Update `README.md` to remove `unittest` guidance, document `pytest`-only testing, and add `pip install` + `pytest -q` instructions.

### Testing
- Verified the requirements files exist: `ls -lah requirements*.txt` produced: `-rw-r--r-- 1 root root 23 Jan 29 18:33 requirements-dev.txt` and `-rw-r--r-- 1 root root 16 Jan 29 18:33 requirements.txt`.
- Attempted to install deps with `python -m pip install -r requirements.txt -r requirements-dev.txt`, but installation failed in this environment due to network/proxy restrictions (could not fetch `pandas`).
- Ran `pytest -q` after the failed install and test collection aborted with missing packages, example error summary: `ModuleNotFoundError: No module named 'requests'` and `ModuleNotFoundError: No module named 'pandas'`, causing pytest to stop during collection (7 errors in collection).
- Commit implementing these changes: `d5ee9f929ceeec5fb65d90077b120f875d9a82d6` which updates `README.md` and adds `requirements.txt` and `requirements-dev.txt` (unified diff recorded in the commit).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ba7bf6fe88323883f51ef4ee21008)