### PR TITLE
Manual close: detector signals to finalize path with throttled two-step detection and tests

### DIFF
--- a/AUDIT_PRODUCT_QUALITY.md
+++ b/AUDIT_PRODUCT_QUALITY.md
@@ -1593,6 +1593,16 @@ Added `SYNC_PERIODIC_SEC=300` to call `sync_from_binance(st, reason="PERIODIC")`
 
 **Current behavior:**
 - `emergency.check_flag()` — reads flag (checks if exists)
+
+---
+
+### 9.3 Manual Close Detection (Finalization-First)
+
+Manual close handling now uses exchange-truth (balances + debt) compared to the baseline snapshot:
+- **Guards**: LONG/SHORT require base+quote totals within EPS and margin debt cleared.
+- **Throttle**: persisted `manual_close_next_check_s` ensures deterministic polling after restart.
+- **Finalization-first**: detector emits a confirm signal and executor runs the existing finalize contract (cleanup → state reset → return).
+- **No spam**: relies on existing trade closed dedupe (`last_notified_close_trade_key`).
 - `emergency.remove_flag()` — deletes flag after processing
 - **No function creates the flag**
 

--- a/docs/MANUAL_CLOSE_DETECTION_TZ.md
+++ b/docs/MANUAL_CLOSE_DETECTION_TZ.md
@@ -407,6 +407,29 @@ Never
 
 Ніяких cleanup
 
+---
+
+## Phase 2 — Exchange-truth Manual Close Detection (Finalization-First)
+
+Статус: ✅ DONE
+
+Зроблено:
+- Реалізовано manual_close_detector.tick() з exchange-truth перевіркою балансів (base/quote) та margin debt.
+- LONG / SHORT guard-умови розділені.
+- Two-step confirmation через manual_close_candidate_s + MANUAL_CLOSE_CONFIRM_SEC.
+- Throttle з персистом (manual_close_next_check_s) для детермінізму після рестарту.
+- Detector лише сигналізує (handled/reason/tag/details); фіналізація виконується через існуючий finalize-contract в executor (_close_slot / _finalize_close).
+- Повторне використання існуючих механізмів: send_trade_closed, report_trade_close, margin_guard.on_after_position_closed.
+
+Tests:
+- Stage 1: no-side-effects test (detector не мутує state і не викликає API).
+- Stage 2: guards (LONG/SHORT), confirm-window, throttle persistence, інтеграційний finalize-path через executor.
+
+Примітки ⚠️:
+- Confirm/throttle залежать від персисту state; при втраті запису підтвердження може відкластися.
+- EPS-пороги зменшують, але не повністю усувають ризик false-positive при баланс-дріфті.
+- Detector навмисно не викликає _close_slot напряму; фіналізація централізована в executor.
+
 Phase 3 — Read-only exchange reality
 
 Before

--- a/executor.py
+++ b/executor.py
@@ -967,57 +967,6 @@ def manage_v15_position(symbol: str, st: Dict[str, Any]) -> None:
         return
     # ================================================================================
 
-    handled = manual_close_detector.tick(st, pos, binance_api, margin_policy, ENV, now_s)
-    if handled:
-        return
-
-    # GATE: Only poll openOrders when status == OPEN (not OPEN_FILLED)
-    # During OPEN_FILLED, rely on place_order responses + retries, not polling
-    orders = []
-    open_orders_ok = False
-    if pos.get("status") == "OPEN":
-        pos.pop("openorders_skip_logged", None)
-        snapshot = get_snapshot()
-        refreshed = refresh_snapshot(
-            symbol=symbol,
-            source="manage",
-            open_orders_fn=binance_api.open_orders,
-            min_interval_sec=float(ENV.get("SNAPSHOT_MIN_SEC", 5)),
-        )
-        if refreshed:
-            log_event(
-                "SNAPSHOT_REFRESH",
-                source="manage",
-                ok=snapshot.ok,
-                error=snapshot.error,
-                age_sec=snapshot.freshness_sec(),
-                order_count=len(snapshot.get_orders()),
-            )
-        orders = snapshot.get_orders()
-        if not snapshot.ok and snapshot.error:
-            # Throttle error logging
-            last_err = float(pos.get("open_orders_err_s") or 0.0)
-            if now_s - last_err >= 30.0:
-                pos["open_orders_err_s"] = now_s
-                st["position"] = pos
-                save_state(st)
-                log_event("LIVE_MANAGE_ERROR", error=f"openOrders: {snapshot.error}")
-        open_orders_ok = bool(snapshot.ok)
-    else:
-        # OPEN_FILLED: skip openOrders polling (log once per position to avoid spam)
-        if not pos.get("openorders_skip_logged"):
-            pos["openorders_skip_logged"] = iso_utc()
-            st["position"] = pos
-            save_state(st)
-            log_event("MANAGE_SKIP_OPENORDERS", status=pos.get("status"), reason="OPEN_FILLED_gate")
-
-    open_ids: set[int] = set()
-    for _o in (orders or []):
-        if not isinstance(_o, dict):
-            continue
-        with suppress(Exception):
-            open_ids.add(int(_o.get("orderId")))
-
     def _update_order_fill(pos: Dict[str, Any], leg: str, payload: Dict[str, Any]) -> bool:
         """Reporting Spec v1: persist execution data from existing status calls."""
         if not isinstance(payload, dict) or not leg:
@@ -1174,6 +1123,63 @@ def manage_v15_position(symbol: str, st: Dict[str, Any]) -> None:
         with suppress(Exception):
             _cancel_sibling_exits_best_effort(tag=tag)
         _close_slot(reason)
+
+    manual_signal = manual_close_detector.tick(st, pos, binance_api, margin_policy, ENV, now_s)
+    if manual_signal.get("state_dirty"):
+        st["position"] = pos
+        save_state(st)
+    if manual_signal.get("handled"):
+        reason = str(manual_signal.get("reason") or "MANUAL_CLOSE_DETECTED")
+        tag = str(manual_signal.get("tag") or "MANUAL_CLOSE_DETECTED_OK")
+        _finalize_close(reason, tag=tag)
+        return
+
+    # GATE: Only poll openOrders when status == OPEN (not OPEN_FILLED)
+    # During OPEN_FILLED, rely on place_order responses + retries, not polling
+    orders = []
+    open_orders_ok = False
+    if pos.get("status") == "OPEN":
+        pos.pop("openorders_skip_logged", None)
+        snapshot = get_snapshot()
+        refreshed = refresh_snapshot(
+            symbol=symbol,
+            source="manage",
+            open_orders_fn=binance_api.open_orders,
+            min_interval_sec=float(ENV.get("SNAPSHOT_MIN_SEC", 5)),
+        )
+        if refreshed:
+            log_event(
+                "SNAPSHOT_REFRESH",
+                source="manage",
+                ok=snapshot.ok,
+                error=snapshot.error,
+                age_sec=snapshot.freshness_sec(),
+                order_count=len(snapshot.get_orders()),
+            )
+        orders = snapshot.get_orders()
+        if not snapshot.ok and snapshot.error:
+            # Throttle error logging
+            last_err = float(pos.get("open_orders_err_s") or 0.0)
+            if now_s - last_err >= 30.0:
+                pos["open_orders_err_s"] = now_s
+                st["position"] = pos
+                save_state(st)
+                log_event("LIVE_MANAGE_ERROR", error=f"openOrders: {snapshot.error}")
+        open_orders_ok = bool(snapshot.ok)
+    else:
+        # OPEN_FILLED: skip openOrders polling (log once per position to avoid spam)
+        if not pos.get("openorders_skip_logged"):
+            pos["openorders_skip_logged"] = iso_utc()
+            st["position"] = pos
+            save_state(st)
+            log_event("MANAGE_SKIP_OPENORDERS", status=pos.get("status"), reason="OPEN_FILLED_gate")
+
+    open_ids: set[int] = set()
+    for _o in (orders or []):
+        if not isinstance(_o, dict):
+            continue
+        with suppress(Exception):
+            open_ids.add(int(_o.get("orderId")))
 
     def _tp1_be_transition_tick() -> bool:
         """Cancel current SL first, then place BE SL (throttled). Returns True if BE placed.

--- a/executor_mod/manual_close_detector.py
+++ b/executor_mod/manual_close_detector.py
@@ -10,5 +10,196 @@ def tick(
     margin_policy: Any,
     env: Dict[str, Any],
     now_s: float,
-) -> bool:
-    return False
+) -> Dict[str, Any]:
+    result: Dict[str, Any] = {
+        "handled": False,
+        "state_dirty": False,
+    }
+
+    if not isinstance(st, dict) or not isinstance(pos, dict):
+        return result
+
+    baseline = st.get("baseline")
+    if not isinstance(baseline, dict):
+        return result
+    active = baseline.get("active")
+    if not isinstance(active, dict):
+        return result
+
+    if pos.get("mode") != "live" or pos.get("status") not in ("OPEN", "OPEN_FILLED"):
+        return result
+
+    check_sec = _get_float(env.get("MANUAL_CLOSE_CHECK_SEC"), 120.0)
+    if check_sec <= 0.0:
+        check_sec = 0.0
+
+    next_check = _get_float(pos.get("manual_close_next_check_s"), 0.0)
+    if now_s < next_check:
+        return result
+
+    pos["manual_close_next_check_s"] = now_s + check_sec
+    result["state_dirty"] = True
+
+    trade_mode = str(env.get("TRADE_MODE", "spot")).strip().lower()
+    symbol = str(env.get("SYMBOL") or pos.get("symbol") or "")
+    base_asset, quote_asset = _split_symbol_assets(symbol, env)
+    if not base_asset or not quote_asset:
+        pos["manual_close_last_error"] = "missing_assets"
+        result["state_dirty"] = True
+        return result
+
+    try:
+        if trade_mode == "margin":
+            is_isolated = _is_true(env.get("MARGIN_ISOLATED", "FALSE"))
+            account = api.margin_account(is_isolated=is_isolated, symbols=symbol)
+            base = margin_policy._asset_snapshot(account, base_asset)
+            quote = margin_policy._asset_snapshot(account, quote_asset)
+            balances = {
+                "base_free": _get_float(base.get("free"), 0.0),
+                "base_locked": _get_float(base.get("locked"), 0.0),
+                "quote_free": _get_float(quote.get("free"), 0.0),
+                "quote_locked": _get_float(quote.get("locked"), 0.0),
+            }
+            debt = api.get_margin_debt_snapshot(
+                symbol=symbol if is_isolated else None,
+                is_isolated=is_isolated,
+            )
+        else:
+            account = _spot_account(api)
+            balances = _spot_balances(account, base_asset, quote_asset)
+            debt = {"has_debt": False}
+    except Exception as exc:
+        pos["manual_close_last_error"] = str(exc)
+        result["state_dirty"] = True
+        return result
+
+    base_total = balances["base_free"] + balances["base_locked"]
+    quote_total = balances["quote_free"] + balances["quote_locked"]
+
+    active_bal = active.get("balances") if isinstance(active.get("balances"), dict) else {}
+    base_base = _get_float(active_bal.get("base_free"), 0.0) + _get_float(active_bal.get("base_locked"), 0.0)
+    quote_base = _get_float(active_bal.get("quote_free"), 0.0) + _get_float(active_bal.get("quote_locked"), 0.0)
+
+    base_delta = base_total - base_base
+    quote_delta = quote_total - quote_base
+
+    base_eps = _get_float(env.get("BASE_EPS"), 0.00001)
+    quote_eps = _get_float(env.get("QUOTE_EPS"), 2.0)
+    if base_eps < 0.0:
+        base_eps = 0.0
+    if quote_eps < 0.0:
+        quote_eps = 0.0
+
+    has_debt = bool(debt.get("has_debt")) if trade_mode == "margin" else False
+    guard_base = abs(base_delta) < base_eps
+    guard_quote = abs(quote_delta) < quote_eps
+
+    side = str(pos.get("side") or "").upper()
+    if side == "LONG":
+        guard = guard_base and guard_quote and (not has_debt if trade_mode == "margin" else True)
+    elif side == "SHORT":
+        guard = (not has_debt) and guard_base and guard_quote
+    else:
+        guard = False
+
+    if guard:
+        candidate = _get_float(pos.get("manual_close_candidate_s"), 0.0)
+        if candidate <= 0.0:
+            pos["manual_close_candidate_s"] = now_s
+            result["state_dirty"] = True
+        else:
+            confirm_sec = _get_float(env.get("MANUAL_CLOSE_CONFIRM_SEC"), check_sec or 120.0)
+            if confirm_sec <= 0.0:
+                confirm_sec = check_sec or 120.0
+            if (now_s - candidate) >= confirm_sec:
+                pos.pop("manual_close_candidate_s", None)
+                result["state_dirty"] = True
+                result["handled"] = True
+                result["reason"] = "MANUAL_CLOSE_DETECTED"
+                result["tag"] = "MANUAL_CLOSE_DETECTED_OK"
+                result["details"] = {
+                    "trade_mode": trade_mode,
+                    "side": side,
+                    "base_total": base_total,
+                    "quote_total": quote_total,
+                    "base_baseline": base_base,
+                    "quote_baseline": quote_base,
+                    "base_delta": base_delta,
+                    "quote_delta": quote_delta,
+                    "has_debt": has_debt,
+                }
+    else:
+        if pos.get("manual_close_candidate_s") is not None:
+            pos.pop("manual_close_candidate_s", None)
+            result["state_dirty"] = True
+
+    return result
+
+
+def _get_float(val: Any, default: float) -> float:
+    try:
+        return float(val if val is not None else default)
+    except Exception:
+        return default
+
+
+def _is_true(val: Any) -> bool:
+    if isinstance(val, bool):
+        return val
+    if val is None:
+        return False
+    return str(val).strip().upper() in ("TRUE", "1", "YES", "Y", "ON")
+
+
+def _spot_account(api: Any) -> Dict[str, Any]:
+    for fn_name in ("account", "get_account", "spot_account", "get_spot_account"):
+        fn = getattr(api, fn_name, None)
+        if callable(fn):
+            return fn()
+    return {}
+
+
+def _spot_balances(account: Dict[str, Any], base_asset: str, quote_asset: str) -> Dict[str, float]:
+    balances = account.get("balances") or account.get("userAssets") or []
+    base_free, base_locked = _find_balance(balances, base_asset)
+    quote_free, quote_locked = _find_balance(balances, quote_asset)
+    return {
+        "base_free": base_free,
+        "base_locked": base_locked,
+        "quote_free": quote_free,
+        "quote_locked": quote_locked,
+    }
+
+
+def _find_balance(balances: Any, asset: str) -> tuple[float, float]:
+    if not isinstance(balances, list):
+        return 0.0, 0.0
+    asset_u = str(asset or "").upper()
+    for row in balances:
+        if not isinstance(row, dict):
+            continue
+        if str(row.get("asset", "")).upper() == asset_u:
+            return _get_float(row.get("free"), 0.0), _get_float(row.get("locked"), 0.0)
+    return 0.0, 0.0
+
+
+def _split_symbol_assets(symbol: str, env: Dict[str, Any]) -> tuple[str, str]:
+    sym = str(symbol or "").strip().upper()
+    if not sym:
+        return "", ""
+
+    base_env = env.get("BASE_ASSET") or env.get("BASE")
+    quote_env = env.get("QUOTE_ASSET") or env.get("QUOTE")
+    if base_env and quote_env:
+        return str(base_env).strip().upper(), str(quote_env).strip().upper()
+
+    quotes = [
+        "USDT", "USDC", "FDUSD", "BUSD", "TUSD", "DAI",
+        "BTC", "ETH", "EUR", "TRY", "BRL", "GBP", "JPY",
+        "AUD", "CAD", "CHF",
+    ]
+    for quote in sorted(quotes, key=len, reverse=True):
+        if sym.endswith(quote) and len(sym) > len(quote):
+            return sym[:-len(quote)], quote
+
+    return "", ""

--- a/test/test_manual_close_detector_stage1.py
+++ b/test/test_manual_close_detector_stage1.py
@@ -25,7 +25,8 @@ def test_tick_stage1_no_side_effects() -> None:
 
     handled = manual_close_detector.tick(st, pos, api, margin_policy, env, 123.0)
 
-    assert handled is False
+    assert handled.get("handled") is False
+    assert handled.get("state_dirty") is False
     assert st == st_before
     assert pos == pos_before
     assert api.method_calls == []

--- a/test/test_manual_close_detector_stage2.py
+++ b/test/test_manual_close_detector_stage2.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from unittest.mock import Mock, patch
+
+from executor_mod import manual_close_detector, margin_policy
+
+
+def _make_env() -> dict:
+    return {
+        "TRADE_MODE": "margin",
+        "SYMBOL": "BTCUSDC",
+        "MARGIN_ISOLATED": "FALSE",
+        "MANUAL_CLOSE_CHECK_SEC": 120.0,
+        "BASE_EPS": 0.00001,
+        "QUOTE_EPS": 2.0,
+    }
+
+
+def _make_margin_account(base_free: float, base_locked: float, quote_free: float, quote_locked: float) -> dict:
+    return {
+        "userAssets": [
+            {"asset": "BTC", "free": str(base_free), "locked": str(base_locked)},
+            {"asset": "USDC", "free": str(quote_free), "locked": str(quote_locked)},
+        ]
+    }
+
+
+def test_manual_close_long_guard_two_step_confirm() -> None:
+    pos = {"mode": "live", "status": "OPEN", "side": "LONG"}
+    st = {
+        "position": pos,
+        "baseline": {
+            "active": {
+                "balances": {
+                    "base_free": 1.0,
+                    "base_locked": 0.0,
+                    "quote_free": 100.0,
+                    "quote_locked": 0.0,
+                }
+            }
+        },
+    }
+    api = Mock()
+    api.margin_account.return_value = _make_margin_account(1.0, 0.0, 100.0, 0.0)
+    api.get_margin_debt_snapshot.return_value = {"has_debt": False}
+    env = _make_env()
+
+    env["MANUAL_CLOSE_CONFIRM_SEC"] = 1.0
+    result_1 = manual_close_detector.tick(st, pos, api, margin_policy, env, 100.0)
+    assert result_1["handled"] is False
+    assert pos.get("manual_close_candidate_s") == 100.0
+
+    result_2 = manual_close_detector.tick(st, pos, api, margin_policy, env, 102.0)
+    assert result_2["handled"] is True
+    assert result_2["reason"] == "MANUAL_CLOSE_DETECTED"
+
+
+def test_manual_close_short_requires_debt_gate() -> None:
+    pos = {"mode": "live", "status": "OPEN", "side": "SHORT"}
+    st = {
+        "position": pos,
+        "baseline": {
+            "active": {
+                "balances": {
+                    "base_free": 0.5,
+                    "base_locked": 0.0,
+                    "quote_free": 250.0,
+                    "quote_locked": 0.0,
+                }
+            }
+        },
+    }
+    api = Mock()
+    api.margin_account.return_value = _make_margin_account(0.5, 0.0, 250.0, 0.0)
+    api.get_margin_debt_snapshot.return_value = {"has_debt": True}
+    env = _make_env()
+
+    result = manual_close_detector.tick(st, pos, api, margin_policy, env, 100.0)
+    assert result["handled"] is False
+    assert pos.get("manual_close_candidate_s") is None
+
+
+def test_manual_close_long_requires_debt_gate() -> None:
+    pos = {"mode": "live", "status": "OPEN", "side": "LONG"}
+    st = {
+        "position": pos,
+        "baseline": {
+            "active": {
+                "balances": {
+                    "base_free": 0.5,
+                    "base_locked": 0.0,
+                    "quote_free": 250.0,
+                    "quote_locked": 0.0,
+                }
+            }
+        },
+    }
+    api = Mock()
+    api.margin_account.return_value = _make_margin_account(0.5, 0.0, 250.0, 0.0)
+    api.get_margin_debt_snapshot.return_value = {"has_debt": True}
+    env = _make_env()
+
+    result = manual_close_detector.tick(st, pos, api, margin_policy, env, 100.0)
+    assert result["handled"] is False
+    assert pos.get("manual_close_candidate_s") is None
+
+
+def test_manual_close_throttle_persistence() -> None:
+    pos = {"mode": "live", "status": "OPEN", "side": "LONG"}
+    st = {
+        "position": pos,
+        "baseline": {
+            "active": {
+                "balances": {
+                    "base_free": 1.0,
+                    "base_locked": 0.0,
+                    "quote_free": 100.0,
+                    "quote_locked": 0.0,
+                }
+            }
+        },
+    }
+    api = Mock()
+    api.margin_account.return_value = _make_margin_account(1.0, 0.0, 100.0, 0.0)
+    api.get_margin_debt_snapshot.return_value = {"has_debt": False}
+    env = _make_env()
+
+    manual_close_detector.tick(st, pos, api, margin_policy, env, 100.0)
+    next_check = pos.get("manual_close_next_check_s")
+    assert next_check == 220.0
+    assert api.margin_account.call_count == 1
+
+    manual_close_detector.tick(st, pos, api, margin_policy, env, 200.0)
+    assert api.margin_account.call_count == 1
+
+
+def test_manual_close_no_finalize_on_first_confirm_tick() -> None:
+    pos = {"mode": "live", "status": "OPEN", "side": "LONG"}
+    st = {
+        "position": pos,
+        "baseline": {
+            "active": {
+                "balances": {
+                    "base_free": 1.0,
+                    "base_locked": 0.0,
+                    "quote_free": 100.0,
+                    "quote_locked": 0.0,
+                }
+            }
+        },
+    }
+    api = Mock()
+    api.margin_account.return_value = _make_margin_account(1.0, 0.0, 100.0, 0.0)
+    api.get_margin_debt_snapshot.return_value = {"has_debt": False}
+    env = _make_env()
+
+    env["MANUAL_CLOSE_CONFIRM_SEC"] = 1.0
+    result = manual_close_detector.tick(st, pos, api, margin_policy, env, 100.0)
+    assert result["handled"] is False
+    assert pos.get("manual_close_candidate_s") == 100.0
+
+
+def test_manual_close_confirm_requires_age_window() -> None:
+    pos = {"mode": "live", "status": "OPEN", "side": "LONG"}
+    st = {
+        "position": pos,
+        "baseline": {
+            "active": {
+                "balances": {
+                    "base_free": 1.0,
+                    "base_locked": 0.0,
+                    "quote_free": 100.0,
+                    "quote_locked": 0.0,
+                }
+            }
+        },
+    }
+    api = Mock()
+    api.margin_account.return_value = _make_margin_account(1.0, 0.0, 100.0, 0.0)
+    api.get_margin_debt_snapshot.return_value = {"has_debt": False}
+    env = _make_env()
+    env["MANUAL_CLOSE_CONFIRM_SEC"] = 200.0
+
+    manual_close_detector.tick(st, pos, api, margin_policy, env, 100.0)
+    result = manual_close_detector.tick(st, pos, api, margin_policy, env, 221.0)
+    assert result["handled"] is False
+    assert pos.get("manual_close_candidate_s") == 100.0
+
+
+@patch("executor.manual_close_detector.tick")
+@patch("executor.report_take_profit")
+@patch("executor.reporting.report_trade_close")
+@patch("executor.margin_guard.on_after_position_closed")
+@patch("executor.save_state")
+@patch("executor.send_trade_closed")
+@patch("executor.log_event")
+@patch("executor.binance_api")
+def test_manual_close_confirm_triggers_finalize(
+    mock_api,
+    mock_log,
+    mock_send_closed,
+    mock_save_state,
+    mock_margin_after_close,
+    mock_report_trade_close,
+    mock_report_tp,
+    mock_tick,
+) -> None:
+    import executor
+
+    env_before = deepcopy(executor.ENV)
+    env = {
+        "SYMBOL": "BTCUSDC",
+        "COOLDOWN_SEC": 10,
+        "TRADE_MODE": "spot",
+    }
+    executor.ENV.update(env)
+
+    pos = {
+        "mode": "live",
+        "status": "OPEN",
+        "side": "LONG",
+        "orders": {"tp1": 1, "tp2": 2, "sl": 3},
+        "prices": {"entry": 100.0},
+    }
+    st = {"position": deepcopy(pos), "baseline": {"active": {"balances": {"base_free": 0.0}}}}
+
+    mock_tick.return_value = {
+        "handled": True,
+        "reason": "MANUAL_CLOSE_DETECTED",
+        "tag": "MANUAL_CLOSE_DETECTED_OK",
+        "details": {"base_delta": 0.0, "quote_delta": 0.0},
+    }
+
+    try:
+        executor.manage_v15_position("BTCUSDC", st)
+    finally:
+        executor.ENV.clear()
+        executor.ENV.update(env_before)
+
+    assert mock_report_trade_close.called
+    assert mock_send_closed.called
+    assert mock_save_state.called
+    assert mock_margin_after_close.called
+    assert st.get("position") is None


### PR DESCRIPTION
### Motivation
- Make manual-close detection deterministic and restart-safe by having a pure detector that only emits a signal and persists throttle/confirm keys in `pos` instead of performing inline cancels/repays/state-reset.
- Reduce false positives by requiring an explicit two-step confirmation window before declaring a manual close.
- Route confirmed manual-close events through the existing finalize contract to preserve finalization-first invariants and existing hooks.

### Description
- Reworked `executor_mod/manual_close_detector.tick(...)` to return a signal dict `{ "handled": bool, "state_dirty": bool, "reason": ..., "tag": ..., "details": ... }` and to only mutate `pos` keys (`manual_close_next_check_s`, `manual_close_candidate_s`, and `manual_close_last_error`) instead of doing inline cleanup.
- Implemented throttling (`manual_close_next_check_s`) and two-step confirmation using `manual_close_candidate_s` with a configurable `MANUAL_CLOSE_CONFIRM_SEC` (falls back to `MANUAL_CLOSE_CHECK_SEC`).
- Applied LONG/SHORT guards comparing exchange totals against `baseline.active.balances` with `BASE_EPS`/`QUOTE_EPS` tolerances and a margin debt gate for margin mode.
- Wired the detector into `manage_v15_position` to call `manual_close_detector.tick(...)` after `_finalize_close` is defined, persist `st` when `state_dirty` is true, and call `_finalize_close(reason, tag)` and return when `handled` is true (keeps finalization-first ordering and existing hooks intact).
- Added helper utilities inside the detector module for robust spot/margin balance extraction and float/boolean parsing, and updated `AUDIT_PRODUCT_QUALITY.md` to clarify that the detector only emits signals and finalization happens via the existing finalize contract.

### Testing
- Added unit tests `test/test_manual_close_detector_stage1.py` (no-side-effect contract) and `test/test_manual_close_detector_stage2.py` exercising the two-step confirm window, throttle persistence, LONG/SHORT debt guards, and an executor-level integration-like test that asserts confirmed `handled=True` flows through finalize (checked via mocks of `reporting.report_trade_close`, `send_trade_closed`, `margin_guard.on_after_position_closed`, and `save_state`).
- Executed `pytest -q` in this environment and test collection failed during import due to missing runtime dependencies (`ModuleNotFoundError: No module named 'requests'` and `ModuleNotFoundError: No module named 'pandas'`), so the new tests could not be run here; the added tests are present and should pass in CI or a developer environment with `requests` and `pandas` installed.
- No other automated tests were executed in this sandbox due to the dependency errors. Please run `pytest -q` in CI or locally after installing required dependencies to validate the new tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bab34bcf083238ba40b225f56cde0)