### PR TITLE
Manual close detector: allow BASE_EPS=0 exact-match and add phase4 test

### DIFF
--- a/executor_mod/manual_close_detector.py
+++ b/executor_mod/manual_close_detector.py
@@ -122,7 +122,7 @@ def tick(
             result["state_dirty"] = True
         return result
 
-    base_close = abs(base_total - base_base) < base_eps
+    base_close = abs(base_total - base_base) <= base_eps
     if side == "SHORT":
         guard_ok = (not has_debt) and base_close
     else:

--- a/test/test_manual_close_detector_phase4.py
+++ b/test/test_manual_close_detector_phase4.py
@@ -136,3 +136,35 @@ def test_confirm_triggers_handled_on_second_tick() -> None:
     details = r2.get("details") or {}
     assert details.get("side") == "LONG"
     assert details.get("has_debt") is False
+
+
+def test_base_eps_zero_allows_exact_match_confirmation() -> None:
+    pos = {"mode": "live", "status": "OPEN", "side": "LONG"}
+    st = _make_state(pos)
+    api = Mock()
+    api.margin_account.return_value = _make_margin_account(1.0, 0.0, 120.0, 0.0)
+    api.get_margin_debt_snapshot.return_value = {"has_debt": False}
+    env = _make_env()
+    env["BASE_EPS"] = 0.0
+
+    with patch("executor_mod.manual_close_detector.log_event"):
+        r1 = manual_close_detector.tick(st, pos, api, margin_policy, env, 100.0)
+
+    assert r1["handled"] is False
+    assert pos.get("manual_close_candidate_s") == 100.0
+
+    with patch("executor_mod.manual_close_detector.log_event"):
+        r2 = manual_close_detector.tick(
+            st,
+            pos,
+            api,
+            margin_policy,
+            env,
+            100.0 + env["MANUAL_CLOSE_CHECK_SEC"] + 0.1,
+        )
+
+    assert r2["handled"] is True
+    assert r2.get("reason") == "MANUAL_CLOSE_DETECTED"
+    assert r2.get("tag") == "MANUAL_CLOSE_DETECTED_OK"
+    details = r2.get("details") or {}
+    assert details.get("has_debt") is False


### PR DESCRIPTION
### Motivation
- Fix a bug where setting `BASE_EPS=0` silently prevented arming manual-close candidates because the code used a strict `<` comparison so an exact zero delta was not treated as a match.

### Description
- Make the base equality guard inclusive by changing `abs(base_total - base_base) < base_eps` to `abs(base_total - base_base) <= base_eps` in `executor_mod/manual_close_detector.py`, and add `test_base_eps_zero_allows_exact_match_confirmation` to `test/test_manual_close_detector_phase4.py` which exercises `TRADE_MODE="margin"`, a baseline of `1.0` BTC, `BASE_EPS=0.0`, and the confirm+throttle timing to ensure the second tick returns `handled=True` with the expected reason/tag and `has_debt=False`.

### Testing
- pytest not run (per instructions).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c67f9244483239cc0b8903f49c934)