### PR TITLE
Manual-close: make BASE_EPS inclusive, add zero-eps test, and update docs

### DIFF
--- a/docs/MANUAL_CLOSE_DETECTION_TZ.md
+++ b/docs/MANUAL_CLOSE_DETECTION_TZ.md
@@ -34,13 +34,13 @@
 
 ### 1.4 Guard-умови для LONG
 Manual close для LONG вважається підтвердженим, якщо **одночасно**:
-1) `abs(current.base_total - baseline.base_total) < BASE_EPS`
+1) `abs(current.base_total - baseline.base_total) <= BASE_EPS`
 2) (Margin) `current_debt.has_debt == False` *(рекомендовано як строгий gate)*
 
 ### 1.5 Guard-умови для SHORT
 Manual close для SHORT вважається підтвердженим, якщо **одночасно**:
 1) `current_debt.has_debt == False` *(обовʼязковий gate)*
-2) `abs(current.base_total - baseline.base_total) < BASE_EPS`
+2) `abs(current.base_total - baseline.base_total) <= BASE_EPS`
 
 Quote не є guard, оскільки quote змінюється на close через PnL + fees.
 
@@ -429,7 +429,7 @@ Never
   - 1-й tick → фіксує manual_close_candidate_s
   - 2-й tick після confirm window + throttle → handled=True
 - Додано guard-умови:
-  - base_close з допуском BASE_EPS
+  - base_close з допуском BASE_EPS (inclusive: `<=`)
   - відсутність боргу (has_debt == False) для LONG/SHORT
 - Реалізовано скидання кандидата, якщо guard перестає виконуватись
 - Прибрано спамний snapshot OK лог

--- a/executor_mod/manual_close_detector.py
+++ b/executor_mod/manual_close_detector.py
@@ -122,7 +122,7 @@ def tick(
             result["state_dirty"] = True
         return result
 
-    base_close = abs(base_total - base_base) < base_eps
+    base_close = abs(base_total - base_base) <= base_eps
     if side == "SHORT":
         guard_ok = (not has_debt) and base_close
     else:

--- a/test/test_manual_close_detector_phase4.py
+++ b/test/test_manual_close_detector_phase4.py
@@ -136,3 +136,35 @@ def test_confirm_triggers_handled_on_second_tick() -> None:
     details = r2.get("details") or {}
     assert details.get("side") == "LONG"
     assert details.get("has_debt") is False
+
+
+def test_base_eps_zero_allows_exact_match_confirmation() -> None:
+    pos = {"mode": "live", "status": "OPEN", "side": "LONG"}
+    st = _make_state(pos)
+    api = Mock()
+    api.margin_account.return_value = _make_margin_account(1.0, 0.0, 120.0, 0.0)
+    api.get_margin_debt_snapshot.return_value = {"has_debt": False}
+    env = _make_env()
+    env["BASE_EPS"] = 0.0
+
+    with patch("executor_mod.manual_close_detector.log_event"):
+        r1 = manual_close_detector.tick(st, pos, api, margin_policy, env, 100.0)
+
+    assert r1["handled"] is False
+    assert pos.get("manual_close_candidate_s") == 100.0
+
+    with patch("executor_mod.manual_close_detector.log_event"):
+        r2 = manual_close_detector.tick(
+            st,
+            pos,
+            api,
+            margin_policy,
+            env,
+            100.0 + env["MANUAL_CLOSE_CHECK_SEC"] + 0.1,
+        )
+
+    assert r2["handled"] is True
+    assert r2.get("reason") == "MANUAL_CLOSE_DETECTED"
+    assert r2.get("tag") == "MANUAL_CLOSE_DETECTED_OK"
+    details = r2.get("details") or {}
+    assert details.get("has_debt") is False


### PR DESCRIPTION
### Motivation
- Fix an edge case where `BASE_EPS=0` could fail to arm/confirm a manual-close because the code used a strict `<` comparison, preventing an exact-zero delta from matching.
- Ensure documentation matches runtime semantics so operators using `BASE_EPS=0` have deterministic behavior and avoid silent non-detection.

### Description
- Change the base-equality guard in `executor_mod/manual_close_detector.py` from `abs(base_total - base_base) < base_eps` to `abs(base_total - base_base) <= base_eps` to allow exact matches when `BASE_EPS` is zero.
- Add `test_base_eps_zero_allows_exact_match_confirmation` to `test/test_manual_close_detector_phase4.py` which exercises `BASE_EPS = 0.0` and validates the 2-step candidate→confirm flow returns `handled=True` with the expected reason/tag and `has_debt == False` on the second tick.
- Update `docs/MANUAL_CLOSE_DETECTION_TZ.md` to replace occurrences of `< BASE_EPS` with `<= BASE_EPS` in the LONG/SHORT guard examples and clarify the Phase 4 guard wording to indicate inclusivity.

### Testing
- A unit test was added: `test_base_eps_zero_allows_exact_match_confirmation` in `test/test_manual_close_detector_phase4.py` to cover the zero-eps exact-match case and confirm behavior; the test file is present in the repo.
- Automated tests were not executed as part of this change (`pytest` not run in the rollout); please run `pytest test/test_manual_close_detector_phase4.py -q` locally or in CI to validate the new test and ensure full test suite passes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c67f9244483239cc0b8903f49c934)