### PR TITLE
Finalize sl_done before orders/prices guard

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -1430,6 +1430,10 @@ def manage_v15_position(symbol: str, st: Dict[str, Any]) -> None:
             _cancel_sibling_exits_best_effort(tag=tag)
         _close_slot(reason)
 
+    if pos.get("sl_done"):
+        _finalize_close("SL", tag="SL_FILLED")
+        return
+
     if not pos.get("orders") or not pos.get("prices"):
         return
 

--- a/test/test_terminal_detection_first.py
+++ b/test/test_terminal_detection_first.py
@@ -138,6 +138,43 @@ class TestTerminalDetectionFirst(unittest.TestCase):
         self.assertIsNone(st.get("position"))
 
     # =========================================================================
+    # CRITICAL TEST 2b: sl_done finalizes even with missing orders/prices
+    # =========================================================================
+    @patch("executor.binance_api")
+    @patch("executor.save_state")
+    @patch("executor.send_webhook")
+    @patch("executor.log_event")
+    def test_sl_done_finalizes_with_missing_orders_prices(
+        self, mock_log, mock_webhook, mock_save, mock_api
+    ):
+        """
+        CRITICAL: If sl_done=True with missing orders/prices, finalize immediately.
+
+        This verifies terminal-first cannot be blocked by partial state.
+        """
+        import executor
+
+        env = self._make_env()
+        executor.ENV.update(env)
+
+        pos = {
+            "mode": "live",
+            "status": "OPEN_FILLED",
+            "side": "LONG",
+            "sl_done": True,
+            "orders": None,
+            "prices": None,
+            "qty": 0.1,
+        }
+        st = {"position": pos}
+
+        with patch.object(executor.manual_close_detector, "tick") as mock_manual:
+            executor.manage_v15_position("BTCUSDC", st)
+
+        mock_manual.assert_not_called()
+        self.assertIsNone(st.get("position"))
+
+    # =========================================================================
     # CRITICAL TEST 3: sl_done=True blocks TP watchdog
     # =========================================================================
     @patch("executor.binance_api")


### PR DESCRIPTION
### Motivation
- A guard `if not pos.get("orders") or not pos.get("prices"): return` could return early before the terminal barrier, so a position with `sl_done=True` and missing/partial `orders`/`prices` would never be finalized after restart.

### Description
- Add an sl_done fast-path immediately after `_finalize_close` helper so that `if pos.get("sl_done"):` calls `_finalize_close("SL", tag="SL_FILLED")` and returns without requiring `orders`/`prices`.
- Add a focused regression test `test_sl_done_finalizes_with_missing_orders_prices` in `test/test_terminal_detection_first.py` which sets `sl_done=True` while `orders` and `prices` are `None`, calls `manage_v15_position(...)`, and asserts the position is finalized and `manual_close_detector.tick` was not called.
- Changes are minimal and avoid refactoring other logic paths; only one-line early-return and one test were added.

### Testing
- Ran `pytest -q` and the full suite passed: `255 passed, 3 subtests passed`.
- Ran the focused file: `pytest -q test/test_terminal_detection_first.py::TestTerminalDetectionFirst` and it passed: `17 passed in 0.88s`.
- The new test verifies that terminal-finalization is no longer blocked by missing or corrupt `orders`/`prices` because the `sl_done` fast-path triggers `_finalize_close` before the orders/prices guard can short-circuit other logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988d0d8f16483238c7c5e986d59b7fd)