### PR TITLE
Avoid status-only TP watchdog payloads

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -1037,6 +1037,19 @@ def manage_v15_position(symbol: str, st: Dict[str, Any]) -> None:
             pos["orders"] = orders
         return changed
 
+    def _fill_payload_from_fills(leg: str, status: str, order_id: int) -> Optional[Dict[str, Any]]:
+        fills = ((pos.get("orders") or {}).get("fills") or {}) if isinstance(pos.get("orders"), dict) else {}
+        if not isinstance(fills, dict):
+            return None
+        leg_data = fills.get(leg)
+        if not isinstance(leg_data, dict):
+            return None
+        executed = leg_data.get("executedQty")
+        orig = leg_data.get("origQty")
+        if executed is None or orig is None:
+            return None
+        return {"status": status, "orderId": order_id, "executedQty": executed, "origQty": orig}
+
     def _save_state_best_effort(where: str) -> None:
         """Watchdog-only persistence: delegates to emergency module for alert/throttle."""
         emergency.save_state_safe(st, where)
@@ -1852,8 +1865,12 @@ def manage_v15_position(symbol: str, st: Dict[str, Any]) -> None:
         if (not tp1_cached) and (not tp1_polled) and poll_due and not tp1_filled:
             pos["tp1_status_next_s"] = now_s + float(ENV["LIVE_STATUS_POLL_EVERY"])
             tp1_status_payload = None
-            with suppress(Exception):
+            try:
                 tp1_status_payload = binance_api.check_order_status(symbol, tp1_id)
+            except Exception:
+                status_polled_ids.add(tp1_id)
+            else:
+                status_polled_ids.add(tp1_id)
             if isinstance(tp1_status_payload, dict):
                 _cache_status_payload(tp1_status_payload)
                 if _update_order_fill(pos, "tp1", tp1_status_payload):
@@ -1909,8 +1926,12 @@ def manage_v15_position(symbol: str, st: Dict[str, Any]) -> None:
             _save_state_best_effort("tp2_status_next_s")
 
             tp2_status_payload = None
-            with suppress(Exception):
+            try:
                 tp2_status_payload = binance_api.check_order_status(symbol, tp2_id)
+            except Exception:
+                status_polled_ids.add(tp2_id)
+            else:
+                status_polled_ids.add(tp2_id)
             if isinstance(tp2_status_payload, dict):
                 _cache_status_payload(tp2_status_payload)
                 if _update_order_fill(pos, "tp2", tp2_status_payload):
@@ -2552,23 +2573,28 @@ def manage_v15_position(symbol: str, st: Dict[str, Any]) -> None:
                 if tp1_id in status_polled_ids:
                     cached_tp1 = tick_order_status.get(tp1_id)
                     if cached_tp1:
-                        tp1_status_payload = {"status": cached_tp1, "orderId": tp1_id}
-                    needs_tp1_status = False
+                        fill_payload = _fill_payload_from_fills("tp1", cached_tp1, tp1_id)
+                        if fill_payload:
+                            tp1_status_payload = fill_payload
+                            needs_tp1_status = False
             if needs_tp1_status:
-                pos["tp1_watchdog_status_next_s"] = now_s + float(ENV.get("LIVE_STATUS_POLL_EVERY") or 0.0)
-                st["position"] = pos
-                _save_state_best_effort("tp1_watchdog_status_poll")
-                try:
-                    tp1_status_payload = binance_api.check_order_status(symbol, tp1_id)
-                    if isinstance(tp1_status_payload, dict):
-                        _cache_status_payload(tp1_status_payload)
-                        if _update_order_fill(pos, "tp1", tp1_status_payload):
-                            st["position"] = pos
-                            _save_state_best_effort("tp1_watchdog_fill_update")
-                except Exception as e:
-                    # If order is missing on exchange, inject synthetic status for planner.
-                    if _is_unknown_order_error(e):
-                        tp1_status_payload = {"status": "MISSING"}
+                if tp1_id not in status_polled_ids:
+                    pos["tp1_watchdog_status_next_s"] = now_s + float(ENV.get("LIVE_STATUS_POLL_EVERY") or 0.0)
+                    st["position"] = pos
+                    _save_state_best_effort("tp1_watchdog_status_poll")
+                    try:
+                        tp1_status_payload = binance_api.check_order_status(symbol, tp1_id)
+                        status_polled_ids.add(tp1_id)
+                        if isinstance(tp1_status_payload, dict):
+                            _cache_status_payload(tp1_status_payload)
+                            if _update_order_fill(pos, "tp1", tp1_status_payload):
+                                st["position"] = pos
+                                _save_state_best_effort("tp1_watchdog_fill_update")
+                    except Exception as e:
+                        status_polled_ids.add(tp1_id)
+                        # If order is missing on exchange, inject synthetic status for planner.
+                        if _is_unknown_order_error(e):
+                            tp1_status_payload = {"status": "MISSING"}
 
         if tp2_id and not pos.get("tp2_done") and not pos.get("tp2_synthetic"):
             needs_tp2_status = (
@@ -2580,22 +2606,27 @@ def manage_v15_position(symbol: str, st: Dict[str, Any]) -> None:
                 if tp2_id in status_polled_ids:
                     cached_tp2 = tick_order_status.get(tp2_id)
                     if cached_tp2:
-                        tp2_status_payload = {"status": cached_tp2, "orderId": tp2_id}
-                    needs_tp2_status = False
+                        fill_payload = _fill_payload_from_fills("tp2", cached_tp2, tp2_id)
+                        if fill_payload:
+                            tp2_status_payload = fill_payload
+                            needs_tp2_status = False
             if needs_tp2_status:
-                pos["tp2_watchdog_status_next_s"] = now_s + float(ENV.get("LIVE_STATUS_POLL_EVERY") or 0.0)
-                st["position"] = pos
-                _save_state_best_effort("tp2_watchdog_status_poll")
-                try:
-                    tp2_status_payload = binance_api.check_order_status(symbol, tp2_id)
-                    if isinstance(tp2_status_payload, dict):
-                        _cache_status_payload(tp2_status_payload)
-                        if _update_order_fill(pos, "tp2", tp2_status_payload):
-                            st["position"] = pos
-                            _save_state_best_effort("tp2_watchdog_fill_update")
-                except Exception as e:
-                    if _is_unknown_order_error(e):
-                        tp2_status_payload = {"status": "MISSING"}
+                if tp2_id not in status_polled_ids:
+                    pos["tp2_watchdog_status_next_s"] = now_s + float(ENV.get("LIVE_STATUS_POLL_EVERY") or 0.0)
+                    st["position"] = pos
+                    _save_state_best_effort("tp2_watchdog_status_poll")
+                    try:
+                        tp2_status_payload = binance_api.check_order_status(symbol, tp2_id)
+                        status_polled_ids.add(tp2_id)
+                        if isinstance(tp2_status_payload, dict):
+                            _cache_status_payload(tp2_status_payload)
+                            if _update_order_fill(pos, "tp2", tp2_status_payload):
+                                st["position"] = pos
+                                _save_state_best_effort("tp2_watchdog_fill_update")
+                    except Exception as e:
+                        status_polled_ids.add(tp2_id)
+                        if _is_unknown_order_error(e):
+                            tp2_status_payload = {"status": "MISSING"}
 
     # Execute TP watchdog (OPEN or OPEN_FILLED status)
     tp_plan = None

--- a/test/test_terminal_detection_first.py
+++ b/test/test_terminal_detection_first.py
@@ -739,6 +739,238 @@ class TestTerminalDetectionFirst(unittest.TestCase):
         self.assertEqual(mock_api.check_order_status.call_count, 1)
 
     # =========================================================================
+    # CRITICAL TEST 12B: TP1 poll single-flight blocks TP watchdog second poll
+    # =========================================================================
+    @patch("executor.binance_api")
+    @patch("executor.save_state")
+    @patch("executor.send_webhook")
+    @patch("executor.log_event")
+    def test_tp1_poll_single_flight_blocks_watchdog_poll(
+        self, mock_log, mock_webhook, mock_save, mock_api
+    ):
+        """TP1 poll block must prevent TP watchdog from re-polling in the same tick."""
+        import executor
+
+        env = self._make_env()
+        executor.ENV.update(env)
+
+        pos = {
+            "mode": "live",
+            "status": "OPEN",
+            "side": "LONG",
+            "orders": {"tp1": 111},
+            "prices": {"tp1": 102.0, "entry": 100.0},
+            "qty": 0.1,
+            "tp1_status_next_s": time.time() - 10.0,
+            "tp1_watchdog_status_next_s": time.time() - 10.0,
+        }
+        st = {"position": pos}
+
+        class _Snap:
+            ok = True
+            error = None
+
+            def get_orders(self):
+                return [{
+                    "orderId": 111,
+                    "status": "NEW",
+                }]
+
+            def freshness_sec(self):
+                return 0.0
+
+        class _PriceSnap:
+            ok = True
+            price_mid = 103.0
+
+        mock_api.open_orders.return_value = []
+        mock_api.check_order_status.return_value = {
+            "status": "NEW",
+            "orderId": 111,
+            "executedQty": "0.0",
+            "origQty": "0.1",
+        }
+
+        with patch.object(executor, "refresh_snapshot", return_value=False), \
+             patch.object(executor, "get_snapshot", return_value=_Snap()), \
+             patch.object(executor.price_snapshot, "refresh_price_snapshot", return_value=None), \
+             patch.object(executor.price_snapshot, "get_price_snapshot", return_value=_PriceSnap()), \
+             patch.object(executor.exit_safety, "sl_watchdog_tick", return_value=None), \
+             patch.object(executor.exit_safety, "tp_watchdog_tick", return_value=None):
+            executor.manage_v15_position("BTCUSDC", st)
+
+        self.assertEqual(mock_api.check_order_status.call_count, 1)
+
+    # =========================================================================
+    # CRITICAL TEST 12C: status-only cached payload uses fills for TP watchdog
+    # =========================================================================
+    @patch("executor.binance_api")
+    @patch("executor.save_state")
+    @patch("executor.send_webhook")
+    @patch("executor.log_event")
+    def test_tp_watchdog_uses_fill_payload_when_cached_status_only(
+        self, mock_log, mock_webhook, mock_save, mock_api
+    ):
+        """TP watchdog should receive executed/orig when cached status is used."""
+        import executor
+
+        env = self._make_env()
+        executor.ENV.update(env)
+
+        pos = {
+            "mode": "live",
+            "status": "OPEN",
+            "side": "LONG",
+            "orders": {
+                "tp1": 111,
+                "fills": {
+                    "tp1": {
+                        "orderId": 111,
+                        "status": "PARTIALLY_FILLED",
+                        "executedQty": "0.045",
+                        "origQty": "0.1",
+                    }
+                },
+            },
+            "prices": {"tp1": 102.0, "entry": 100.0},
+            "qty": 0.1,
+            "tp1_status_next_s": time.time() - 10.0,
+            "tp1_watchdog_status_next_s": time.time() - 10.0,
+        }
+        st = {"position": pos}
+
+        class _Snap:
+            ok = True
+            error = None
+
+            def get_orders(self):
+                return [{
+                    "orderId": 111,
+                    "status": "NEW",
+                }]
+
+            def freshness_sec(self):
+                return 0.0
+
+        class _PriceSnap:
+            ok = True
+            price_mid = 103.0
+
+        captured = {"args": None, "kwargs": None}
+
+        def _capture_tp_watchdog(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return None
+
+        mock_api.open_orders.return_value = []
+        mock_api.check_order_status.return_value = {
+            "status": "NEW",
+            "orderId": 111,
+            "executedQty": "0.0",
+            "origQty": "0.1",
+        }
+
+        with patch.object(executor, "refresh_snapshot", return_value=False), \
+             patch.object(executor, "get_snapshot", return_value=_Snap()), \
+             patch.object(executor.price_snapshot, "refresh_price_snapshot", return_value=None), \
+             patch.object(executor.price_snapshot, "get_price_snapshot", return_value=_PriceSnap()), \
+             patch.object(executor.exit_safety, "sl_watchdog_tick", return_value=None), \
+             patch.object(executor.exit_safety, "tp_watchdog_tick", side_effect=_capture_tp_watchdog):
+            executor.manage_v15_position("BTCUSDC", st)
+
+        payload = None
+        if captured.get("kwargs") and "tp1_status_payload" in captured["kwargs"]:
+            payload = captured["kwargs"]["tp1_status_payload"]
+        if payload is None and captured.get("args"):
+            for arg in captured["args"]:
+                if isinstance(arg, dict) and arg.get("orderId") == 111:
+                    payload = arg
+                    break
+            if payload is None and len(captured["args"]) >= 7:
+                payload = captured["args"][5]
+        payload = payload or {}
+        self.assertIn("executedQty", payload)
+        self.assertIn("origQty", payload)
+
+    # =========================================================================
+    # CRITICAL TEST 12D: cached status without fills should not pass status-only payload
+    # =========================================================================
+    @patch("executor.binance_api")
+    @patch("executor.save_state")
+    @patch("executor.send_webhook")
+    @patch("executor.log_event")
+    def test_tp_watchdog_skips_status_only_when_fills_missing(
+        self, mock_log, mock_webhook, mock_save, mock_api
+    ):
+        """TP watchdog should not receive status-only payload without fill qtys."""
+        import executor
+
+        env = self._make_env()
+        executor.ENV.update(env)
+
+        pos = {
+            "mode": "live",
+            "status": "OPEN",
+            "side": "LONG",
+            "orders": {"tp1": 111},
+            "prices": {"tp1": 102.0, "entry": 100.0},
+            "qty": 0.1,
+            "tp1_status_next_s": time.time() - 10.0,
+            "tp1_watchdog_status_next_s": time.time() - 10.0,
+        }
+        st = {"position": pos}
+
+        class _Snap:
+            ok = True
+            error = None
+
+            def get_orders(self):
+                return []
+
+            def freshness_sec(self):
+                return 0.0
+
+        class _PriceSnap:
+            ok = True
+            price_mid = 103.0
+
+        captured = {"args": None, "kwargs": None}
+
+        def _capture_tp_watchdog(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return None
+
+        mock_api.open_orders.return_value = []
+        mock_api.check_order_status.return_value = {
+            "status": "NEW",
+            "orderId": 111,
+        }
+
+        with patch.object(executor, "refresh_snapshot", return_value=False), \
+             patch.object(executor, "get_snapshot", return_value=_Snap()), \
+             patch.object(executor.price_snapshot, "refresh_price_snapshot", return_value=None), \
+             patch.object(executor.price_snapshot, "get_price_snapshot", return_value=_PriceSnap()), \
+             patch.object(executor.exit_safety, "sl_watchdog_tick", return_value=None), \
+             patch.object(executor.exit_safety, "tp_watchdog_tick", side_effect=_capture_tp_watchdog):
+            executor.manage_v15_position("BTCUSDC", st)
+
+        payload = None
+        if captured.get("kwargs") and "tp1_status_payload" in captured["kwargs"]:
+            payload = captured["kwargs"]["tp1_status_payload"]
+        if payload is None and captured.get("args"):
+            for arg in captured["args"]:
+                if isinstance(arg, dict) and arg.get("orderId") == 111:
+                    payload = arg
+                    break
+            if payload is None and len(captured["args"]) >= 7:
+                payload = captured["args"][5]
+        if payload is not None:
+            self.assertIn("executedQty", payload)
+            self.assertIn("origQty", payload)
+
+    # =========================================================================
     # CRITICAL TEST 13: TP terminal proof avoids qty2/qty3-only confirmation
     # =========================================================================
     @patch("executor.binance_api")


### PR DESCRIPTION
### Motivation
- Prevent TP watchdog from receiving `status`-only cached payloads that lack `executedQty`/`origQty`, because that breaks partial-fill detection and can hide partial fills in the same tick.  
- Preserve the single-flight invariant (avoid duplicate `check_order_status` calls per tick) while ensuring the watchdog either receives fills-backed qty data or is allowed to poll instead of being fed an incomplete payload.

### Description
- Stop injecting cached `status`-only payloads into the TP watchdog for `tp1` and `tp2`, and only pass a payload when we can synthesize `executedQty`/`origQty` from `pos["orders"]["fills"]`.  
- Use the existing fills-derived helper (kept minimal) to build a full payload when fills are present and contain qty fields, otherwise leave the watchdog payload as `None` so it may poll when permitted.  
- Harden tests in `test/test_terminal_detection_first.py` to capture `tp_watchdog_tick` arguments robustly (capture `args`/`kwargs`), add a negative test that ensures no status-only payload is forwarded when fills are missing, and keep the single-flight poll-count test intact.

### Testing
- Phase 0 evidence (verbatim outputs):
```
$ git status -sb
## work
```
```
$ git log --oneline -n 10
de71f3e Enforce TP status single-flight and payload completeness
29b2371 Merge pull request #136 from Mykh-Ai/codex/manually-port-changes-to-current-head
641f661 Guard manual close detector after terminal barrier
af015f3 Merge pull request #135 from Mykh-Ai/codex/conduct-evidence-audit-for-trading-bot
a64f4c6 Harden terminal probe throttling and TP proof
fa54770 Merge pull request #134 from Mykh-Ai/codex/collect-code-evidence-for-exit-logic
ef69ce3 Enforce terminal barrier before watchdog markets
3eeeb74 Test: enforce finalization-first contract for SL FILLED
1fc93e8 Fix tick-cache poisoning from openOrders snapshot
3c4da5c Fix: set TRADE_CLOSED dedup only on webhook 2xx
```
```
$ rg -n "_fill_payload_from_fills|status_polled_ids.add\(|tp1_watchdog_status_next_s|tp2_watchdog_status_next_s" executor.py
1040:    def _fill_payload_from_fills(leg: str, status: str, order_id: int) -> Optional[Dict[str, Any]]:
1215:            status_polled_ids.add(int(order_id))
1871:                status_polled_ids.add(tp1_id)
1873:                status_polled_ids.add(tp1_id)
1932:                status_polled_ids.add(tp2_id)
1934:                status_polled_ids.add(tp2_id)
2571:            next_tp1_status = float(pos.get("tp1_watchdog_status_next_s") or 0.0)
2576:                        fill_payload = _fill_payload_from_fills("tp1", cached_tp1, tp1_id)
2584:                    pos["tp1_watchdog_status_next_s"] = now_s + float(ENV.get("LIVE_STATUS_POLL_EVERY") or 0.0)
2589:                        status_polled_ids.add(tp1_id)
2596:                        status_polled_ids.add(tp1_id)
2606:            next_tp2_status = float(pos.get("tp2_watchdog_status_next_s") or 0.0)
2611:                        fill_payload = _fill_payload_from_fills("tp2", cached_tp2, tp2_id)
2619:                    pos["tp2_watchdog_status_next_s"] = now_s + float(ENV.get("LIVE_STATUS_POLL_EVERY") or 0.0)
2624:                        status_polled_ids.add(tp2_id)
2631:                        status_polled_ids.add(tp2_id)
```
```
$ rg -n "tp_watchdog_tick\(" executor.py executor_mod/exit_safety.py
executor_mod/exit_safety.py:325:def tp_watchdog_tick(
executor.py:2656:            tp_plan = exit_safety.tp_watchdog_tick(
```
```
$ pytest -q
........................................................................ [ 28%]
......
..
256 passed, 3 subtests passed in 553.02s (0:09:13)
```
- Confirmations from Phase 0: the TP watchdog cached-path previously synthesized payloads in `executor.py` near the `tp1/tp2` watchdog blocks (see the `fill_payload = _fill_payload_from_fills(...)` and the now-removed status-only injection lines), and `tp_watchdog_tick` expects `executedQty`/`origQty` to correctly handle partial fills.  
- Post-change automated test run: `pytest -q` after changes reported `257 passed, 3 subtests passed in 551.99s (0:09:11)`, showing all tests (including the new/updated ones) passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988d9e946d88323968c9dbc412c0b7e)