### PR TITLE
Fix TP watchdog throttle gating

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -2573,7 +2573,8 @@ def manage_v15_position(symbol: str, st: Dict[str, Any]) -> None:
                 or ("origQty" not in tp1_status_payload)
             )
             next_tp1_status = float(pos.get("tp1_watchdog_status_next_s") or 0.0)
-            if needs_tp1_status and (now_s >= next_tp1_status or (not orders)):
+            tp1_watchdog_due = now_s >= next_tp1_status
+            if needs_tp1_status and tp1_watchdog_due:
                 if tp1_id in status_polled_ids:
                     cached_tp1 = tick_order_status.get(tp1_id)
                     if cached_tp1:
@@ -2581,7 +2582,7 @@ def manage_v15_position(symbol: str, st: Dict[str, Any]) -> None:
                         if fill_payload:
                             tp1_status_payload = fill_payload
                             needs_tp1_status = False
-            if needs_tp1_status:
+            if needs_tp1_status and tp1_watchdog_due:
                 if tp1_id not in status_polled_ids:
                     pos["tp1_watchdog_status_next_s"] = now_s + float(ENV.get("LIVE_STATUS_POLL_EVERY") or 0.0)
                     st["position"] = pos
@@ -2606,7 +2607,8 @@ def manage_v15_position(symbol: str, st: Dict[str, Any]) -> None:
                 or ("status" not in tp2_status_payload)
             )
             next_tp2_status = float(pos.get("tp2_watchdog_status_next_s") or 0.0)
-            if needs_tp2_status and (now_s >= next_tp2_status or (not orders)):
+            tp2_watchdog_due = now_s >= next_tp2_status
+            if needs_tp2_status and tp2_watchdog_due:
                 if tp2_id in status_polled_ids:
                     cached_tp2 = tick_order_status.get(tp2_id)
                     if cached_tp2:
@@ -2614,7 +2616,7 @@ def manage_v15_position(symbol: str, st: Dict[str, Any]) -> None:
                         if fill_payload:
                             tp2_status_payload = fill_payload
                             needs_tp2_status = False
-            if needs_tp2_status:
+            if needs_tp2_status and tp2_watchdog_due:
                 if tp2_id not in status_polled_ids:
                     pos["tp2_watchdog_status_next_s"] = now_s + float(ENV.get("LIVE_STATUS_POLL_EVERY") or 0.0)
                     st["position"] = pos

--- a/test/test_terminal_detection_first.py
+++ b/test/test_terminal_detection_first.py
@@ -839,6 +839,114 @@ class TestTerminalDetectionFirst(unittest.TestCase):
         self.assertEqual(mock_api.check_order_status.call_count, 1)
 
     # =========================================================================
+    # CRITICAL TEST 12B-1: TP watchdog does not bypass throttle on empty orders
+    # =========================================================================
+    @patch("executor.binance_api")
+    @patch("executor.save_state")
+    @patch("executor.send_webhook")
+    @patch("executor.log_event")
+    def test_tp1_watchdog_empty_orders_does_not_force_poll(
+        self, mock_log, mock_webhook, mock_save, mock_api
+    ):
+        """Empty openOrders with snapshot ok must not force TP watchdog polling."""
+        import executor
+
+        env = self._make_env()
+        executor.ENV.update(env)
+
+        pos = {
+            "mode": "live",
+            "status": "OPEN",
+            "side": "LONG",
+            "orders": {"tp1": 111},
+            "prices": {"tp1": 102.0, "entry": 100.0},
+            "qty": 0.1,
+            "tp1_status_next_s": time.time() + 60.0,
+            "tp1_watchdog_status_next_s": time.time() + 60.0,
+        }
+        st = {"position": pos}
+
+        class _Snap:
+            ok = True
+            error = None
+
+            def get_orders(self):
+                return []
+
+            def freshness_sec(self):
+                return 0.0
+
+        class _PriceSnap:
+            ok = True
+            price_mid = 103.0
+
+        mock_api.open_orders.return_value = []
+
+        with patch.object(executor, "refresh_snapshot", return_value=False), \
+             patch.object(executor, "get_snapshot", return_value=_Snap()), \
+             patch.object(executor.price_snapshot, "refresh_price_snapshot", return_value=None), \
+             patch.object(executor.price_snapshot, "get_price_snapshot", return_value=_PriceSnap()), \
+             patch.object(executor.exit_safety, "sl_watchdog_tick", return_value=None), \
+             patch.object(executor.exit_safety, "tp_watchdog_tick", return_value=None):
+            executor.manage_v15_position("BTCUSDC", st)
+
+        self.assertEqual(mock_api.check_order_status.call_count, 0)
+
+    # =========================================================================
+    # CRITICAL TEST 12B-2: snapshot not ok still does not bypass throttle
+    # =========================================================================
+    @patch("executor.binance_api")
+    @patch("executor.save_state")
+    @patch("executor.send_webhook")
+    @patch("executor.log_event")
+    def test_tp1_watchdog_snapshot_not_ok_does_not_force_poll(
+        self, mock_log, mock_webhook, mock_save, mock_api
+    ):
+        """Snapshot not ok must not force TP watchdog polling before throttle."""
+        import executor
+
+        env = self._make_env()
+        executor.ENV.update(env)
+
+        pos = {
+            "mode": "live",
+            "status": "OPEN",
+            "side": "LONG",
+            "orders": {"tp1": 111},
+            "prices": {"tp1": 102.0, "entry": 100.0},
+            "qty": 0.1,
+            "tp1_status_next_s": time.time() + 60.0,
+            "tp1_watchdog_status_next_s": time.time() + 60.0,
+        }
+        st = {"position": pos}
+
+        class _Snap:
+            ok = False
+            error = "boom"
+
+            def get_orders(self):
+                return []
+
+            def freshness_sec(self):
+                return 0.0
+
+        class _PriceSnap:
+            ok = True
+            price_mid = 103.0
+
+        mock_api.open_orders.return_value = []
+
+        with patch.object(executor, "refresh_snapshot", return_value=False), \
+             patch.object(executor, "get_snapshot", return_value=_Snap()), \
+             patch.object(executor.price_snapshot, "refresh_price_snapshot", return_value=None), \
+             patch.object(executor.price_snapshot, "get_price_snapshot", return_value=_PriceSnap()), \
+             patch.object(executor.exit_safety, "sl_watchdog_tick", return_value=None), \
+             patch.object(executor.exit_safety, "tp_watchdog_tick", return_value=None):
+            executor.manage_v15_position("BTCUSDC", st)
+
+        self.assertEqual(mock_api.check_order_status.call_count, 0)
+
+    # =========================================================================
     # CRITICAL TEST 12C: status-only cached payload uses fills for TP watchdog
     # =========================================================================
     @patch("executor.binance_api")


### PR DESCRIPTION
### Motivation
- TP watchdog could bypass the throttle when `orders == []`, causing unexpected `check_order_status()` calls; this breaks API stability guarantees and allowed unthrottled polling in some snapshot scenarios.
- The intent is to remove the empty-orders bypass while keeping existing throttle keys and single-flight protection intact, and to add regression tests that prevent regressions.

### Description
- Modify TP watchdog gating in `executor.py` so TP1/TP2 status polling only runs when the watchdog throttle is due by introducing `tp1_watchdog_due` / `tp2_watchdog_due` and removing the `(not orders)` bypass, while preserving `status_polled_ids` single-flight logic and cached-fill handling.
- Add two regression tests to `test/test_terminal_detection_first.py` that assert `binance_api.check_order_status` is NOT called when `orders == []` or when snapshot is not OK and the watchdog poll is not due.
- Keep all changes minimal and local: no new persistent keys, no refactors, and existing watchdog timing keys (`tp1_watchdog_status_next_s` / `tp2_watchdog_status_next_s`) are reused.

### Testing
- Ran full unit suite with `pytest -q`; final run produced: `260 passed, 3 subtests passed` (tests added included and passing).

Phase 0 evidence (verbatim outputs):
### `git status -sb`
```
## work
```

### `git log --oneline -n 20`
```
6c157af Merge pull request #138 from Mykh-Ai/codex/audit-trading-bot-for-i3,-i4,-tp-correctness
bc7d49e Merge pull request #137 from Mykh-Ai/codex/provide-evidence-for-early-return-behavior
0661c4d Avoid status-only TP watchdog payloads
ad9309d Finalize sl_done before guard
29b2371 Merge pull request #136 from Mykh-Ai/codex/manually-port-changes-to-current-head
641f661 Guard manual close detector after terminal barrier
af015f3 Merge pull request #135 from Mykh-Ai/codex/conduct-evidence-audit-for-trading-bot
a64f4c6 Harden terminal probe throttling and TP proof
fa54770 Merge pull request #134 from Mykh-Ai/codex/collect-code-evidence-for-exit-logic
ef69ce3 Enforce terminal barrier before watchdog markets
3eeeb74 Test: enforce finalization-first contract for SL FILLED
1fc93e8 Fix tick-cache poisoning from openOrders snapshot
3c4da5c Fix: set TRADE_CLOSED dedup only on webhook 2xx
4ee89cb Merge pull request #133 from Mykh-Ai/codex/audit-order-status-cache-and-call-paths
c7d59e2 Fix sl_prev cache mapping and harden tests
53033a7 Merge pull request #132 from Mykh-Ai/codex/fix-sl-finalization-failure-bug
5616e88 Enforce SL watchdog pre-market safeguards
ea3ca26 Merge pull request #131 from Mykh-Ai/codex/apply-patch-to-test_manual_close_phase7.py
7aad8f4 Update manual close notification test
da24a91 Merge pull request #130 from Mykh-Ai/codex/add-targeted-tests-for-manual-close-phase-6-k8885k
```

### `rg -n "needs_tp1_status|needs_tp2_status|tp1_watchdog_status_next_s|tp2_watchdog_status_next_s|\\(not orders\\)" executor.py`
```
1742:        if needs_status and (status_poll_due or (not orders)) and now_s >= next_status:
2569:            needs_tp1_status = (
2575:            next_tp1_status = float(pos.get("tp1_watchdog_status_next_s") or 0.0)
2576:            if needs_tp1_status and (now_s >= next_tp1_status or (not orders)):
2583:                            needs_tp1_status = False
2584:            if needs_tp1_status:
2586:                    pos["tp1_watchdog_status_next_s"] = now_s + float(ENV.get("LIVE_STATUS_POLL_EVERY") or 0.0)
2604:            needs_tp2_status = (
2608:            next_tp2_status = float(pos.get("tp2_watchdog_status_next_s") or 0.0)
2609:            if needs_tp2_status and (now_s >= next_tp2_status or (not orders)):
2616:                            needs_tp2_status = False
2617:            if needs_tp2_status:
2619:                    pos["tp2_watchdog_status_next_s"] = now_s + float(ENV.get("LIVE_STATUS_POLL_EVERY") or 0.0)
```

### `rg -n "open_orders_ok|snapshot\\.ok|MANAGE_SKIP_OPENORDERS" executor.py`
```
1203:        if open_orders_ok and int(order_id) in open_ids:
1207:        missing_from_open = open_orders_ok and int(order_id) not in open_ids
1456:    open_orders_ok = False
1470:                ok=snapshot.ok,
1476:        if not snapshot.ok and snapshot.error:
1484:        open_orders_ok = bool(snapshot.ok)
1491:            log_event("MANAGE_SKIP_OPENORDERS", status=pos.get("status"), reason="OPEN_FILLED_gate")
1978:                    if snapshot.ok:
2134:                if snapshot.ok:
2292:        if snapshot.ok:
2642:        if snapshot.ok:
2857:                if open_orders_ok and order_id in open_ids:
3113:    if snapshot.is_fresh(float(ENV.get("SNAPSHOT_MIN_SEC", 5))) and snapshot.ok:
3121:            snapshot.ok = True
```

### `pytest -q` (Phase 0 run before patch)
```
........................................................................ [ 27%]
........................................................................ [ 55%]
........................................................................ [ 83%]
..........................................                            [100%]
258 passed, 3 subtests passed in 552.51s (0:09:12)
```

Post-change test run: `pytest -q` →
```
260 passed, 3 subtests passed in 551.97s (0:09:11)
```

What changed and how to validate locally: apply the diff and run `pytest -q`; confirm the two new tests in `test/test_terminal_detection_first.py` pass and that there are no additional calls to `binance_api.check_order_status` when `tp1_watchdog_status_next_s` is in the future and `orders == []` (the tests assert this behavior).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988f1bd2e4883239e8b4454bb1a0de3)