### PR TITLE
docs: Phase 1 research archive spec and live-bus isolation for DeltaScout

### DIFF
--- a/deltascout/README.md
+++ b/deltascout/README.md
@@ -23,6 +23,9 @@ DeltaScout monitors the aggregated trade feed produced by the Aggregator (`aggre
   - one JSON object per line
   - includes event types such as `PEAK` and warmup/init events (`INIT_MAX`, `INIT_MIN`) depending on settings
 
+`deltascout.log` is the live PEAK bus for Buyer/Executor. Planned research instrumentation
+must write to a separate archive file path and must not reuse this bus file.
+
 ## Configuration
 
 The script uses environment variables for configuration.
@@ -45,4 +48,3 @@ Install deps:
 
 ```bash
 pip install pandas numpy
-

--- a/docs/DeltaScout_Research_Phase1_Spec.md
+++ b/docs/DeltaScout_Research_Phase1_Spec.md
@@ -44,7 +44,7 @@ Aggregator
 DeltaScout
     │  reads:  aggregated.csv (tail polling, POLL_SECS=20)
     │  stdout: Δ1m max/min/zero/init_* lines (Docker logs)
-    │  writes: /data/logs/deltascout.log (JSONL: PEAK, INIT_MAX, INIT_MIN, TIER_TP1)
+    │  writes: /data/logs/deltascout.log (JSONL: PEAK, INIT_MAX, INIT_MIN)
     ├──────────────────┐
     ▼                  ▼
   Buyer            Executor
@@ -63,6 +63,11 @@ DeltaScout
 | Executor log       | `/data/logs/executor.log`           | `EXEC_LOG`          |
 | Executor state     | `/data/state/executor_state.json`   | `STATE_FN`          |
 | Buyer state        | `/root/volume-alert/buyer_state.json` | `STATE_FN`        |
+
+> Implementation note: defaults are not fully harmonized across modules (for example,
+> Buyer path defaults differ from DeltaScout/Executor defaults). Phase 1 archive
+> implementation must use explicit archive path configuration and must not assume
+> all services already share identical defaults.
 
 ### Confirmed log channels
 
@@ -277,6 +282,18 @@ during the trade, and how it closed — in a single self-contained artifact.
 
 ## Phase 1 Research Events (Planned)
 
+### Smallest safe Patch 1 scope (frozen)
+
+Patch 1 must log only the following additive research events:
+
+- `DELTA_MAX`
+- `DELTA_MIN`
+- `CANDIDATE_COMPARISON_REJECT`
+- `CANDIDATE_GATE_REJECT`
+
+These events are additive research instrumentation only and must not change
+PEAK emission, thresholds, gates, cooldown/state logic, or Buyer/Executor contracts.
+
 These events will be emitted to a dedicated research archive (not `deltascout.log`)
 in a future implementation phase:
 
@@ -289,6 +306,17 @@ in a future implementation phase:
 | `WINDOW_OWNERSHIP_MISS`       | Strong delta but not window owner | ts, delta, vol, imb, price, window_max, window_min |
 | `PEAK_EMIT`                   | Successful PEAK (mirror)         | Full PEAK payload + gate_values (chop30, coh10, ema50) |
 | `EXEC_CLOSE`                  | Position closed                  | ts, reason, entry, exit, pnl, triggering_peak, position_state |
+
+### Patch 1 out of scope
+
+The following are explicitly excluded from the smallest Patch 1:
+
+- `PEAK_EMIT`
+- Executor close linkage / `EXEC_CLOSE`
+- Runtime `WINDOW_OWNERSHIP_MISS` emission (offline-derived only)
+- Buyer/Executor contract changes
+- Any PEAK payload or PEAK path change
+- Large archive-manager abstraction
 
 ### Reject classification
 
@@ -463,8 +491,8 @@ Phase 1 implementation will **directly log** a subset of these events in real ti
 | `DELTA_MAX` / `DELTA_MIN` | yes | Raw peaks — foundation for all analysis |
 | `CANDIDATE_COMPARISON_REJECT` | yes | Direct insertion at `return` statements |
 | `CANDIDATE_GATE_REJECT` | yes | Direct insertion at `return` statements |
-| `PEAK_EMIT` | yes | Mirror of live PEAK with enriched context |
-| `EXEC_CLOSE` | yes | Executor close snapshots |
+| `PEAK_EMIT` | no (Patch 1) | Out of smallest patch scope; can be added later in a separate change |
+| `EXEC_CLOSE` | no (Patch 1) | Out of smallest patch scope; requires separate executor linkage work |
 | `WINDOW_OWNER_MISS` | **derived** | Computed offline by comparing `DELTA_MAX/MIN` timestamps against feed data |
 | `BASELINE_INITIALIZATION_EVENT` | **derived** | Identifiable from `DELTA_MAX/MIN` sequences where no comparison event follows |
 | `LATE_PEAK_RECOGNITION` | **derived** | Computed offline by measuring price move before `PEAK_EMIT` timestamp |
@@ -477,10 +505,12 @@ mandatory event stream.
 
 ### Research archive layout (planned)
 
-All research data lives under the local runtime root:
+Canonical runtime root for Phase 1 archive writes is `/data`.
+
+All research data for Phase 1 lives under:
 
 ```
-/root/volume-alert/data/archive/
+/data/archive/
     deltascout/
         YYYY-MM-DD.jsonl          # decision-level research events
     executor_close/
@@ -490,6 +520,12 @@ All research data lives under the local runtime root:
 ```
 
 This archive is append-only and never read by the live trading system.
+
+### Live bus isolation requirements (mandatory)
+
+- Research archive must use a separate archive file and must not reuse `deltascout.log`.
+- Research archive writes must not go through the live-bus truncation logic used for `deltascout.log`.
+- Research archive must remain fully isolated from Buyer/Executor PEAK bus consumers.
 
 ### Record format
 
@@ -523,13 +559,12 @@ writable or locally available at runtime.
 
 ## Runtime Topology Note
 
-This Phase 1 archive is local to the DeltaScout / volume-alert environment
-under `/root/volume-alert`.
+Current repository/runtime defaults are mixed between `/data/...` and `/root/volume-alert/...`.
+For Phase 1 implementation, archive pathing is canonicalized to `/data/archive/...` for
+implementation safety.
 
-- Runtime project root: `/root/volume-alert`
-- DeltaScout code: `/root/volume-alert/delta_scout.py`
-- Live data: `/root/volume-alert/data/` (feed, logs, state)
-- Research archive: `/root/volume-alert/data/archive/`
+- Live data and bus defaults in code: `/data/feed`, `/data/logs`, `/data/state`
+- Research archive (Phase 1 canonical): `/data/archive/`
 
 Any datasets under `/opt/aitrader` or other containers/projects are
 external references only and are not part of the local runtime root.
@@ -542,4 +577,11 @@ external references only and are not part of the local runtime root.
 - Research events must be **additive** (new code paths only, no modification of existing logic)
 - Research archive must be **isolated** from the live signal bus (`deltascout.log`)
 - Research logging must not introduce latency into the hot path
+- Archive writes must be **soft-fail**: write errors must never block or alter PEAK emission
+- Archive writes must not alter `handle_row()` control flow or state behavior
 - All research events must include a monotonic sequence number for ordering
+
+## Dormant Runtime Item Note
+
+`TIER_TP1` exists in code as a helper path, but it is not part of the verified active
+runtime emission flow and is not in scope for the smallest Phase 1 patch unless explicitly wired later.

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,16 +34,20 @@ The system maintains four data channels relevant to research and analysis:
 
 | Channel | Path | Format | Role |
 |---------|------|--------|------|
-| **Canonical input** | `/root/volume-alert/data/feed/aggregated.csv` (live) | CSV, 10 columns | Minute-level market feed from Aggregator |
-| **Decision archive** | *(planned)* `/root/volume-alert/data/archive/deltascout/YYYY-MM-DD.jsonl` | JSONL | Research delta archive capturing every decision point |
+| **Canonical input** | `/data/feed/aggregated.csv` (live) | CSV, 10 columns | Minute-level market feed from Aggregator |
+| **Decision archive** | *(planned)* `/data/archive/deltascout/YYYY-MM-DD.jsonl` | JSONL | Research delta archive capturing additive Phase 1 decision events |
 | **Live signal bus** | `/data/logs/deltascout.log` | JSONL | PEAK events consumed by Buyer and Executor |
 | **Execution outcome** | `/data/logs/executor.log` | JSONL | Executor action log (open, close, state transitions) |
+
+Implementation safety notes:
+- Research archive is a separate file/channel and must not reuse `deltascout.log`.
+- Research archive writes must not use live-bus truncation behavior.
+- Module defaults may still diverge (`/data/...` vs `/root/volume-alert/...`), so deployment must set explicit paths.
 
 For the full research infrastructure specification, see [DeltaScout_Research_Phase1_Spec.md](DeltaScout_Research_Phase1_Spec.md).
 
 ## Notes
 This repository is intended as a **portfolio and technical showcase**
 to demonstrate system design and engineering approach.
-
 
 


### PR DESCRIPTION
### Motivation

- Ensure research instrumentation is isolated from the live PEAK bus and cannot accidentally reuse or interfere with `deltascout.log`.
- Define a minimal, additive Phase 1 event set and a clear out-of-scope list so research logging does not change runtime behavior or Buyer/Executor contracts.
- Canonicalize runtime/archive paths and clarify topology to reduce deployment confusion and accidental file-path mismatches.

### Description

- Update `deltascout/README.md` to declare `deltascout.log` as the live PEAK bus and to warn that research instrumentation must write to a separate archive path.
- Revise `docs/DeltaScout_Research_Phase1_Spec.md` to canonicalize the Phase 1 archive root to `/data/archive`, enumerate the smallest Patch 1 additive events (`DELTA_MAX`, `DELTA_MIN`, `CANDIDATE_COMPARISON_REJECT`, `CANDIDATE_GATE_REJECT`) and explicitly mark `PEAK_EMIT`/`EXEC_CLOSE` and other items as out of scope for Patch 1.
- Add mandatory live-bus isolation and archive constraints, including that archive writes must not use live-bus truncation, must be isolated from Buyer/Executor consumers, must be soft-fail (cannot block PEAK emission), and must not alter `handle_row()` control flow or state behavior.
- Update `docs/README.md` to use canonical `/data` paths for feed and archive references and to include implementation safety notes about separate archive files and explicit path configuration.

### Testing

- This is a documentation-only change; no unit or integration tests were applicable or modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7e3bcb2a48323a985617471533c7f)