### PR TITLE
Normalize close-event identity, robust empty peak handling, and add dedupe/date tests

### DIFF
--- a/scripts/offline/build_close_outcomes.py
+++ b/scripts/offline/build_close_outcomes.py
@@ -24,7 +24,17 @@ def _safe_load_json(path: Path) -> dict[str, Any]:
 def _load_peak_events(archive_file: Path) -> pd.DataFrame:
     rows = [r for r in read_jsonl(archive_file) if r.get("event") == "PEAK_EMIT"]
     if not rows:
-        return pd.DataFrame(columns=["event_ts", "kind", "price", "delta", "imb", "vol", "seq"])
+        return pd.DataFrame(
+            {
+                "event_ts": pd.Series(dtype="datetime64[ns, UTC]"),
+                "kind": pd.Series(dtype="object"),
+                "price": pd.Series(dtype="float64"),
+                "delta": pd.Series(dtype="float64"),
+                "imb": pd.Series(dtype="float64"),
+                "vol": pd.Series(dtype="float64"),
+                "seq": pd.Series(dtype="Int64"),
+            }
+        )
     df = pd.DataFrame(rows)
     df["event_ts"] = pd.to_datetime(df["ts"], utc=True, errors="coerce")
     if df["event_ts"].isna().any():
@@ -57,16 +67,26 @@ def _load_close_events(exec_log_file: Path, state_file: Path) -> list[dict[str, 
 
 
 def _close_identity_key(row: dict[str, Any]) -> str:
-    ts = str(row.get("ts") or row.get("closed_at") or "")
-    reason = str(row.get("reason") or row.get("close_reason") or "")
-    mode = str(row.get("mode") or "")
-    side = str(row.get("side") or "")
-    close_price = str(row.get("close_price") or "")
-    entry = str(row.get("entry") or "")
-    sl = str(row.get("sl") or "")
+    close_ts = pd.to_datetime(row.get("ts") or row.get("closed_at"), utc=True, errors="coerce")
+    # tiny skew tolerance for cross-source evidence (e.g. log vs state +/-1s)
+    ts = "" if pd.isna(close_ts) else close_ts.floor("2s").isoformat()
+    reason = str(row.get("reason") or row.get("close_reason") or "").strip().upper()
+    mode = str(row.get("mode") or "").strip().upper()
+    side = str(row.get("side") or "").strip().upper()
+
+    def _norm_num(v: Any) -> str:
+        try:
+            return f"{float(v):.8f}"
+        except Exception:
+            return ""
+
+    close_price = _norm_num(row.get("close_price"))
+    entry = _norm_num(row.get("entry"))
+    sl = _norm_num(row.get("sl"))
     src_evt = row.get("src_evt") if isinstance(row.get("src_evt"), dict) else {}
-    src_evt_ts = str(src_evt.get("ts") or "")
-    src_evt_kind = str(src_evt.get("kind") or "")
+    src_evt_ts_parsed = pd.to_datetime(src_evt.get("ts"), utc=True, errors="coerce")
+    src_evt_ts = "" if pd.isna(src_evt_ts_parsed) else src_evt_ts_parsed.floor("s").isoformat()
+    src_evt_kind = str(src_evt.get("kind") or "").strip().lower()
     raw = "|".join([ts, reason, mode, side, close_price, entry, sl, src_evt_ts, src_evt_kind])
     return hashlib.sha1(raw.encode("utf-8")).hexdigest()
 

--- a/tests/offline/test_phase1_builders.py
+++ b/tests/offline/test_phase1_builders.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import pandas as pd
 
 from scripts.offline.build_close_outcomes import (
+    _filter_df_by_date as _filter_close_df_by_date,
     _dedupe_close_events,
     _filter_close_events_by_date,
+    _load_peak_events,
     derive_close_outcomes,
 )
 from scripts.offline.build_phase1_derived import _filter_df_by_date, derive_reject_dataset
@@ -96,4 +98,64 @@ def test_close_dedup_state_and_log_duplicate():
     daily = _filter_close_events_by_date(events, "2026-01-01")
     deduped = _dedupe_close_events(daily)
     assert len(daily) == 2
+    assert len(deduped) == 1
+
+
+def test_close_date_filter_with_no_peak_rows_does_not_crash(tmp_path):
+    archive = tmp_path / "empty.jsonl"
+    archive.write_text("", encoding="utf-8")
+    peaks = _load_peak_events(archive)
+
+    scoped = _filter_close_df_by_date(peaks, "event_ts", "2026-01-01")
+    assert scoped.empty
+    assert str(scoped["event_ts"].dtype) == "datetime64[ns, UTC]"
+
+
+def test_close_dedup_log_and_state_same_close_with_shape_differences():
+    log_evt = {
+        "ts": "2026-01-01T00:30:00.987Z",
+        "side": "LONG",
+        "mode": "paper",
+        "reason": "tp1",
+        "close_price": 102,
+        "entry": "100.000000",
+        "sl": 99.0,
+        "src_evt": {"ts": "2026-01-01T00:10:00.200Z", "kind": "LONG", "price": 100.0},
+    }
+    state_evt = {
+        "closed_at": "2026-01-01T00:30:00Z",
+        "side": " long ",
+        "mode": "PAPER",
+        "close_reason": "TP1",
+        "close_price": "102.0",
+        "entry": 100,
+        "sl": "99",
+        "src_evt": {"ts": "2026-01-01T00:10:00Z", "kind": "long"},
+    }
+    deduped = _dedupe_close_events([log_evt, state_evt])
+    assert len(deduped) == 1
+
+
+def test_close_dedup_log_and_state_one_second_timestamp_skew():
+    log_evt = {
+        "ts": "2026-01-01T00:30:01Z",
+        "side": "LONG",
+        "mode": "paper",
+        "reason": "TP1",
+        "close_price": 102.0,
+        "entry": 100.0,
+        "sl": 99.0,
+        "src_evt": {"ts": "2026-01-01T00:10:00Z", "kind": "long"},
+    }
+    state_evt = {
+        "closed_at": "2026-01-01T00:30:00Z",
+        "side": "LONG",
+        "mode": "paper",
+        "close_reason": "TP1",
+        "close_price": 102.0,
+        "entry": 100.0,
+        "sl": 99.0,
+        "src_evt": {"ts": "2026-01-01T00:10:00Z", "kind": "long"},
+    }
+    deduped = _dedupe_close_events([log_evt, state_evt])
     assert len(deduped) == 1


### PR DESCRIPTION
### Motivation

- Ensure deterministic deduplication of close events across sources that may differ in formatting, numeric types, casing, or small timestamp skews. 
- Prevent crashes and dtype surprises when an archive contains no `PEAK_EMIT` rows by returning a typed empty DataFrame.

### Description

- Make `_load_peak_events` return an empty DataFrame with explicit dtypes (timezone-aware `event_ts`, typed numeric columns, and nullable `seq`) when there are no `PEAK_EMIT` rows. 
- Make `_close_identity_key` normalize fields used to build the dedupe key by parsing timestamps with `pandas`, applying a 2-second floor tolerance for close timestamps, normalizing `src_evt` timestamp to second granularity, trimming and uppercasing/casing fields (`reason`, `mode`, `side`, `src_evt.kind`), and normalizing numeric values to a fixed float string format. 
- Keep deduplication deterministic in `_dedupe_close_events` by using the normalized identity key. 
- Update tests to import the adjusted helpers and add tests covering empty peak archives, deduping across log/state events with different shapes/formatting, and a one-second timestamp skew scenario.

### Testing

- Ran `pytest tests/offline/test_phase1_builders.py` which includes the new tests `test_close_date_filter_with_no_peak_rows_does_not_crash`, `test_close_dedup_log_and_state_same_close_with_shape_differences`, and `test_close_dedup_log_and_state_one_second_timestamp_skew`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b83bf67da4832397d31565f66febb1)