### PR TITLE
Improve close-event deduplication and date scoping; add tests

### DIFF
--- a/scripts/offline/build_close_outcomes.py
+++ b/scripts/offline/build_close_outcomes.py
@@ -24,7 +24,17 @@ def _safe_load_json(path: Path) -> dict[str, Any]:
 def _load_peak_events(archive_file: Path) -> pd.DataFrame:
     rows = [r for r in read_jsonl(archive_file) if r.get("event") == "PEAK_EMIT"]
     if not rows:
-        return pd.DataFrame(columns=["event_ts", "kind", "price", "delta", "imb", "vol", "seq"])
+        return pd.DataFrame(
+            {
+                "event_ts": pd.Series(dtype="datetime64[ns, UTC]"),
+                "kind": pd.Series(dtype="object"),
+                "price": pd.Series(dtype="float64"),
+                "delta": pd.Series(dtype="float64"),
+                "imb": pd.Series(dtype="float64"),
+                "vol": pd.Series(dtype="float64"),
+                "seq": pd.Series(dtype="int64"),
+            }
+        )
     df = pd.DataFrame(rows)
     df["event_ts"] = pd.to_datetime(df["ts"], utc=True, errors="coerce")
     if df["event_ts"].isna().any():
@@ -36,6 +46,11 @@ def _filter_df_by_date(df: pd.DataFrame, ts_col: str, source_date: str) -> pd.Da
     out = df.copy()
     if ts_col not in out.columns:
         raise OfflineBuildError(f"missing timestamp column '{ts_col}' for date scoping")
+    if out.empty:
+        return out
+    out[ts_col] = pd.to_datetime(out[ts_col], utc=True, errors="coerce")
+    if out[ts_col].isna().any():
+        raise OfflineBuildError(f"invalid timestamp values in '{ts_col}' for date scoping")
     out["_date"] = out[ts_col].dt.strftime("%Y-%m-%d")
     out = out[out["_date"] == source_date].copy()
     return out.drop(columns=["_date"])
@@ -57,17 +72,42 @@ def _load_close_events(exec_log_file: Path, state_file: Path) -> list[dict[str, 
 
 
 def _close_identity_key(row: dict[str, Any]) -> str:
-    ts = str(row.get("ts") or row.get("closed_at") or "")
-    reason = str(row.get("reason") or row.get("close_reason") or "")
-    mode = str(row.get("mode") or "")
-    side = str(row.get("side") or "")
-    close_price = str(row.get("close_price") or "")
-    entry = str(row.get("entry") or "")
-    sl = str(row.get("sl") or "")
+    def _norm_scalar(v: Any) -> str:
+        if v is None:
+            return ""
+        if isinstance(v, (int, float)):
+            return f"{float(v):.8f}"
+        return str(v)
+
+    def _norm_text(v: Any, *, upper: bool = False, lower: bool = False) -> str:
+        text = _norm_scalar(v).strip()
+        if upper:
+            return text.upper()
+        if lower:
+            return text.lower()
+        return text
+
+    reason = _norm_text(row.get("reason") or row.get("close_reason"), upper=True)
+    mode = _norm_text(row.get("mode"), upper=True)
+    side = _norm_text(row.get("side"), upper=True)
+    close_price = _norm_scalar(row.get("close_price"))
+    entry = _norm_scalar(row.get("entry"))
+    sl = _norm_scalar(row.get("sl"))
     src_evt = row.get("src_evt") if isinstance(row.get("src_evt"), dict) else {}
-    src_evt_ts = str(src_evt.get("ts") or "")
-    src_evt_kind = str(src_evt.get("kind") or "")
-    raw = "|".join([ts, reason, mode, side, close_price, entry, sl, src_evt_ts, src_evt_kind])
+    src_evt_ts = _norm_scalar(src_evt.get("ts"))
+    src_evt_kind = _norm_text(src_evt.get("kind"), lower=True)
+    src_evt_price = _norm_scalar(src_evt.get("price"))
+
+    # executor.log and state.last_closed often emit different close timestamps for the
+    # same close; when src_evt is present prefer a ts-free key so cross-source evidence
+    # hashes together. Without src_evt, keep a coarse time bucket to avoid collapsing
+    # unrelated closes that happen to share reason/price.
+    fallback_ts = pd.to_datetime(row.get("ts") or row.get("closed_at"), utc=True, errors="coerce")
+    ts_bucket = ""
+    if pd.notna(fallback_ts) and not src_evt_ts:
+        ts_bucket = fallback_ts.floor("min").isoformat()
+
+    raw = "|".join([reason, mode, side, close_price, entry, sl, src_evt_ts, src_evt_kind, src_evt_price, ts_bucket])
     return hashlib.sha1(raw.encode("utf-8")).hexdigest()
 
 

--- a/tests/offline/test_phase1_builders.py
+++ b/tests/offline/test_phase1_builders.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pandas as pd
 
 from scripts.offline.build_close_outcomes import (
+    _filter_df_by_date as _filter_close_df_by_date,
     _dedupe_close_events,
     _filter_close_events_by_date,
     derive_close_outcomes,
@@ -96,4 +97,63 @@ def test_close_dedup_state_and_log_duplicate():
     daily = _filter_close_events_by_date(events, "2026-01-01")
     deduped = _dedupe_close_events(daily)
     assert len(daily) == 2
+    assert len(deduped) == 1
+
+
+def test_close_date_scoping_handles_empty_peak_frame():
+    peaks = _filter_close_df_by_date(
+        pd.DataFrame(columns=["event_ts", "kind", "price", "delta", "imb", "vol", "seq"]),
+        "event_ts",
+        "2026-01-01",
+    )
+    assert peaks.empty
+
+
+def test_close_dedup_cross_source_with_different_close_ts():
+    log_row = {
+        "ts": "2026-01-01T00:30:02Z",
+        "side": "LONG",
+        "mode": "paper",
+        "reason": "TP1",
+        "close_price": 102.0,
+        "entry": 100.0,
+        "sl": 99.0,
+        "src_evt": {"ts": "2026-01-01T00:10:00Z", "kind": "long", "price": 100.0},
+    }
+    state_row = {
+        "closed_at": "2026-01-01T00:30:06Z",
+        "side": "LONG",
+        "mode": "paper",
+        "close_reason": "TP1",
+        "close_price": 102,
+        "entry": 100,
+        "sl": 99,
+        "src_evt": {"ts": "2026-01-01T00:10:00Z", "kind": "long", "price": 100},
+    }
+    deduped = _dedupe_close_events([log_row, state_row])
+    assert len(deduped) == 1
+
+
+def test_close_dedup_cross_source_ignores_case_and_whitespace():
+    log_row = {
+        "ts": "2026-01-01T00:30:02Z",
+        "side": " LONG ",
+        "mode": " Paper ",
+        "reason": " tp1 ",
+        "close_price": 102.0,
+        "entry": 100.0,
+        "sl": 99.0,
+        "src_evt": {"ts": "2026-01-01T00:10:00Z", "kind": " Long ", "price": 100.0},
+    }
+    state_row = {
+        "closed_at": "2026-01-01T00:30:06Z",
+        "side": "long",
+        "mode": "PAPER",
+        "close_reason": "TP1",
+        "close_price": 102,
+        "entry": 100,
+        "sl": 99,
+        "src_evt": {"ts": "2026-01-01T00:10:00Z", "kind": "long", "price": 100},
+    }
+    deduped = _dedupe_close_events([log_row, state_row])
     assert len(deduped) == 1


### PR DESCRIPTION
### Motivation
- Make close/outcome building more robust when inputs are empty or have slightly different representations across sources, and avoid spurious duplicate closes when executor log and state snapshots disagree on timestamps.

### Description
- Return a properly typed empty DataFrame from `scripts/offline/build_close_outcomes.py::_load_peak_events` so downstream date-scoping and dtype-sensitive logic behave consistently.
- Harden `scripts/offline/build_close_outcomes.py::_filter_df_by_date` to handle empty frames and validate/parse timestamp columns before scoping by date.
- Rework `scripts/offline/build_close_outcomes.py::_close_identity_key` to normalize numeric/text scalar values, ignore case/whitespace for textual fields, include `src_evt.price`, and add a coarse `ts_bucket` fallback so the same logical close that has different close timestamps across `executor.log` and `executor_state.json` still deduplicates.
- Preserve deterministic dedupe semantics in `_dedupe_close_events` while improving key stability across sources.
- Update tests in `tests/offline/test_phase1_builders.py` to import the correct date-filter helper and add tests covering empty peak frames and cross-source deduplication behavior (different close timestamps and case/whitespace differences).

### Testing
- Ran the offline tests under `tests/offline` with `pytest`; the new and existing unit tests passed.  All added tests (`test_close_date_scoping_handles_empty_peak_frame`, `test_close_dedup_cross_source_with_different_close_ts`, `test_close_dedup_cross_source_ignores_case_and_whitespace`) succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b841d611bc83238e78fcf44b73e7d6)