### PR TITLE
Add Delta Analyzer Phase 2 events_context dataset

### DIFF
--- a/deltascout/delta_analyzer/Delta_Analyzer_Phase2_Spec.md
+++ b/deltascout/delta_analyzer/Delta_Analyzer_Phase2_Spec.md
@@ -1,0 +1,131 @@
+# Delta Analyzer Phase 2 Spec
+
+## Goal
+
+Extend the Phase 1 foundation with `events_context`, a research-only dataset that attaches multi-horizon flow context, backward-looking price context, and VWAP location to each archive event.
+
+This layer should help answer:
+
+- what local delta context preceded the event?
+- what broader flow context preceded the event?
+- how far was price from VWAP at the event?
+- was the event aligned with local flow or sitting inside a conflicting broader backdrop?
+
+## Scope
+
+Phase 2 includes:
+
+- all Phase 1 ingestion, matching, and integrity behavior
+- a new `events_context` dataset builder
+- rolling cumulative-delta context fields
+- backward-looking price-delta context fields
+- VWAP distance fields
+- a CLI mode that can build `events_context` and summarize context coverage
+
+## Non-Goals
+
+Phase 2 does not include:
+
+- outcomes or forward returns
+- EMA, trend, or regime logic
+- setup classification
+- scoring or ranking
+- session segmentation
+- ML
+- production DeltaScout logic
+
+## events_context Field Contract
+
+Each `events_context` row contains all `events_base` fields plus:
+
+- `cum_delta_24h`
+- `cum_delta_180m`
+- `cum_delta_60m`
+- `cum_delta_utc_day`
+- `ret_15m`
+- `ret_60m`
+- `dist_vwap`
+- `abs_dist_vwap`
+- `price_vs_vwap_side`
+
+## Definitions
+
+### Feed price source
+
+Use `ClosePrice` from the feed when present. If `ClosePrice` is missing, fall back to `AvgPrice`.
+
+### Feed delta per row
+
+Per-row feed delta is:
+
+- `BuyQty - SellQty`
+
+### Rolling cumulative delta windows
+
+For each event timestamp `event_ts`, rolling windows include all feed rows where:
+
+- `feed_ts <= event_ts`
+- `feed_ts` is inside the requested lookback duration
+
+Fields:
+
+- `cum_delta_24h`: rolling cumulative delta over the last 24 hours ending at `event_ts`
+- `cum_delta_180m`: rolling cumulative delta over the last 180 minutes ending at `event_ts`
+- `cum_delta_60m`: rolling cumulative delta over the last 60 minutes ending at `event_ts`
+
+If full history is not available, compute with whatever feed rows exist in the window. Do not pad or extrapolate.
+
+### UTC day cumulative delta reference
+
+- `cum_delta_utc_day`: cumulative delta from `00:00 UTC` on the event date through `event_ts`
+
+This field is a reference frame and must remain distinct from `cum_delta_24h`.
+
+### Return fields
+
+`ret_15m` and `ret_60m` are simple backward-looking price differences, not percentages:
+
+- `ret_15m = matched_price_at_event - matched_price_at_or_before(event_ts - 15m)`
+- `ret_60m = matched_price_at_event - matched_price_at_or_before(event_ts - 60m)`
+
+If no earlier feed row exists at or before the lookback boundary, the return field must be `null`.
+
+### VWAP fields
+
+- `dist_vwap = event_price - event_vwap`
+- `abs_dist_vwap = abs(dist_vwap)`
+- `price_vs_vwap_side` is an explicit categorical field:
+  - `above`
+  - `below`
+  - `at_or_unknown`
+
+If event price or VWAP is missing, VWAP-derived fields stay null and `price_vs_vwap_side` becomes `at_or_unknown`.
+
+## CLI Contract
+
+Command:
+
+```bash
+python -m deltascout.delta_analyzer.cli
+```
+
+CLI responsibilities in Phase 2:
+
+- load archive and feed files
+- always build `events_base`
+- optionally build `events_context` via `--dataset events_context` (default)
+- run integrity checks on `events_base`
+- print a concise summary including dataset row counts and context coverage
+
+## Acceptance Criteria
+
+Phase 2 is acceptable if:
+
+1. `events_context` builds from local research materials
+2. required context fields are attached when underlying data exists
+3. `cum_delta_24h` is clearly distinct from `cum_delta_utc_day`
+4. `cum_delta_60m` and `cum_delta_180m` are rolling windows ending at the event timestamp
+5. VWAP distance fields are present
+6. backward-looking price context fields are present
+7. the CLI runs successfully and prints a concise summary
+8. no production DeltaScout logic is modified

--- a/deltascout/delta_analyzer/README.md
+++ b/deltascout/delta_analyzer/README.md
@@ -9,6 +9,7 @@ It exists to build a clean base layer for future analyzer work around:
 - event-to-feed matching
 - base event dataset creation
 - archive and matching health checks
+- backward-looking context reconstruction
 
 ## Phase 1 Scope
 
@@ -24,9 +25,28 @@ Phase 1 implements only the foundation layer:
 
 In Phase 1, `terminal_decision_present` is a heuristic flag based on same `(ts, kind)` presence of any non-raw event. It is not yet a strict lineage or terminal-pair guarantee.
 
+## Phase 2 Scope
+
+Phase 2 adds `events_context`, a research-only extension of `events_base` that reconstructs backward-looking flow and price context around each event.
+
+Phase 2 currently adds:
+
+- rolling cumulative delta over `24h`, `180m`, and `60m`
+- UTC-day cumulative delta as an explicit reference frame (`cum_delta_utc_day`)
+- backward-looking price deltas over `15m` and `60m`
+- event-price distance from VWAP
+
+Important naming rule:
+
+- `cum_delta_24h` means rolling cumulative delta over the last 24 hours ending at the event timestamp
+- `cum_delta_utc_day` means cumulative delta from `00:00 UTC` to the event timestamp
+- these two fields must remain distinct and are not interchangeable
+
+The `ret_15m` and `ret_60m` fields are simple backward-looking price differences, not percentage returns.
+
 ## Not Implemented
 
-Phase 1 does not implement:
+`delta_analyzer` still does not implement:
 
 - outcomes
 - EMA or trend logic
@@ -48,6 +68,8 @@ Optional overrides:
 
 ```bash
 python -m deltascout.delta_analyzer.cli --archive-glob "deltascout/research_material/raw_archive/*.jsonl" --feed-glob "deltascout/research_material/raw_feed/*.csv"
+python -m deltascout.delta_analyzer.cli --dataset events_base
+python -m deltascout.delta_analyzer.cli --dataset events_context
 ```
 
 The default globs already point to the local research-material folder copied for DeltaScout research.

--- a/deltascout/delta_analyzer/__init__.py
+++ b/deltascout/delta_analyzer/__init__.py
@@ -1,6 +1,7 @@
 """DeltaScout research analyzer foundation."""
 
 from .modules.build_events_base import build_events_base_dataset
+from .modules.build_events_context import build_events_context_dataset
 from .modules.integrity_checks import run_integrity_checks
 
-__all__ = ["build_events_base_dataset", "run_integrity_checks"]
+__all__ = ["build_events_base_dataset", "build_events_context_dataset", "run_integrity_checks"]

--- a/deltascout/delta_analyzer/cli.py
+++ b/deltascout/delta_analyzer/cli.py
@@ -8,14 +8,33 @@ from pathlib import Path
 from .config import DEFAULT_ARCHIVE_GLOB, DEFAULT_FEED_GLOB
 from .modules.archive_reader import read_archive_events
 from .modules.build_events_base import build_events_base_dataset
+from .modules.build_events_context import build_events_context_dataset
 from .modules.feed_reader import read_feed_rows
 from .modules.integrity_checks import run_integrity_checks
 
 
+DATASET_CHOICES = ("events_base", "events_context")
+CONTEXT_COVERAGE_FIELDS = (
+    "cum_delta_24h",
+    "cum_delta_180m",
+    "cum_delta_60m",
+    "cum_delta_utc_day",
+    "ret_15m",
+    "ret_60m",
+    "dist_vwap",
+)
+
+
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="DeltaScout delta_analyzer Phase 1 CLI")
+    parser = argparse.ArgumentParser(description="DeltaScout delta_analyzer CLI")
     parser.add_argument("--archive-glob", default=DEFAULT_ARCHIVE_GLOB, help="Glob for archive JSONL files")
     parser.add_argument("--feed-glob", default=DEFAULT_FEED_GLOB, help="Glob for feed CSV files")
+    parser.add_argument(
+        "--dataset",
+        choices=DATASET_CHOICES,
+        default="events_context",
+        help="Highest dataset layer to build. events_context also builds events_base.",
+    )
     return parser
 
 
@@ -30,16 +49,20 @@ def main() -> None:
 
     events = read_archive_events(archive_files)
     feed_rows = read_feed_rows(feed_files)
-    dataset = build_events_base_dataset(events, feed_rows)
-    checks = run_integrity_checks(dataset)
+    events_base = build_events_base_dataset(events, feed_rows)
+    events_context = []
+    if args.dataset == "events_context":
+        events_context = build_events_context_dataset(events_base, feed_rows)
+    checks = run_integrity_checks(events_base)
 
-    event_counts = Counter(row.event_type for row in dataset)
+    event_counts = Counter(row.event_type for row in events_base)
 
-    print("Delta Analyzer Phase 1 Summary")
+    print(f"Delta Analyzer Summary ({args.dataset})")
     print(f"archive_files={len(archive_files)}")
     print(f"feed_files={len(feed_files)}")
     print(f"events={len(events)}")
-    print(f"events_base_rows={len(dataset)}")
+    print(f"events_base_rows={len(events_base)}")
+    print(f"events_context_rows={len(events_context)}")
     print(f"event_type_counts={dict(event_counts)}")
     print(f"missing_feed_match_count={checks.missing_feed_match_count}")
     print(f"multi_event_timestamps={checks.multi_event_timestamps}")
@@ -49,6 +72,12 @@ def main() -> None:
         print("unmatched_event_samples=")
         for item in checks.unmatched_events[:5]:
             print(f"  - {item}")
+    if events_context:
+        print("context_non_null_coverage=")
+        total_rows = len(events_context)
+        for field in CONTEXT_COVERAGE_FIELDS:
+            non_null = sum(1 for row in events_context if getattr(row, field) is not None)
+            print(f"  {field}={non_null}/{total_rows}")
 
 
 if __name__ == "__main__":

--- a/deltascout/delta_analyzer/modules/__init__.py
+++ b/deltascout/delta_analyzer/modules/__init__.py
@@ -1,1 +1,1 @@
-"""Phase 1 modules for delta_analyzer."""
+"""Phase 1 and Phase 2 modules for delta_analyzer."""

--- a/deltascout/delta_analyzer/modules/build_events_context.py
+++ b/deltascout/delta_analyzer/modules/build_events_context.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from ..types import EventsBaseRow, EventsContextRow, FeedRow
+from .context_features import FeedContextIndex
+
+
+def build_events_context_dataset(
+    base_rows: list[EventsBaseRow],
+    feed_rows: list[FeedRow],
+) -> list[EventsContextRow]:
+    """Extend Phase 1 rows with backward-looking flow and price context.
+
+    Rolling windows use all available feed rows inside each lookback window and do
+    not pad missing history; partial history is preserved as-is for honest research.
+    """
+
+    context_index = FeedContextIndex(feed_rows)
+    dataset: list[EventsContextRow] = []
+
+    for row in base_rows:
+        dist_vwap, abs_dist_vwap, price_vs_vwap_side = context_index.dist_vwap(row.price, row.vwap)
+        dataset.append(
+            EventsContextRow(
+                ts=row.ts,
+                event_type=row.event_type,
+                kind=row.kind,
+                reject_reason=row.reject_reason,
+                delta=row.delta,
+                vol=row.vol,
+                imb=row.imb,
+                price=row.price,
+                vwap=row.vwap,
+                poc=row.poc,
+                matched_feed_ts=row.matched_feed_ts,
+                source_file=row.source_file,
+                terminal_decision_present=row.terminal_decision_present,
+                cum_delta_24h=context_index.rolling_cum_delta(row.ts, timedelta(hours=24)),
+                cum_delta_180m=context_index.rolling_cum_delta(row.ts, timedelta(minutes=180)),
+                cum_delta_60m=context_index.rolling_cum_delta(row.ts, timedelta(minutes=60)),
+                cum_delta_utc_day=context_index.utc_day_cum_delta(row.ts),
+                ret_15m=context_index.price_delta(row.ts, timedelta(minutes=15)),
+                ret_60m=context_index.price_delta(row.ts, timedelta(minutes=60)),
+                dist_vwap=dist_vwap,
+                abs_dist_vwap=abs_dist_vwap,
+                price_vs_vwap_side=price_vs_vwap_side,
+            )
+        )
+    return dataset

--- a/deltascout/delta_analyzer/modules/context_features.py
+++ b/deltascout/delta_analyzer/modules/context_features.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from bisect import bisect_right
+from datetime import datetime, timedelta
+
+from ..types import FeedRow
+
+PRICE_VS_VWAP_AT_OR_UNKNOWN = "at_or_unknown"
+PRICE_VS_VWAP_ABOVE = "above"
+PRICE_VS_VWAP_BELOW = "below"
+
+
+class FeedContextIndex:
+    """Index feed rows once so research datasets can reuse consistent context math."""
+
+    def __init__(self, feed_rows: list[FeedRow]):
+        self.feed_rows = sorted(feed_rows, key=lambda item: item.ts)
+        self.feed_ts = [row.ts for row in self.feed_rows]
+        self.prefix_delta = self._build_prefix_delta()
+
+    def match_row(self, event_ts: datetime) -> FeedRow | None:
+        idx = self._index_at_or_before(event_ts)
+        if idx is None:
+            return None
+        return self.feed_rows[idx]
+
+    def rolling_cum_delta(self, event_ts: datetime, lookback: timedelta) -> float | None:
+        end_idx = self._index_at_or_before(event_ts)
+        if end_idx is None:
+            return None
+        start_boundary = event_ts - lookback
+        start_idx = bisect_right(self.feed_ts, start_boundary - timedelta(microseconds=1))
+        return self.prefix_delta[end_idx + 1] - self.prefix_delta[start_idx]
+
+    def utc_day_cum_delta(self, event_ts: datetime) -> float | None:
+        end_idx = self._index_at_or_before(event_ts)
+        if end_idx is None:
+            return None
+        day_start = event_ts.replace(hour=0, minute=0, second=0, microsecond=0)
+        start_idx = bisect_right(self.feed_ts, day_start - timedelta(microseconds=1))
+        return self.prefix_delta[end_idx + 1] - self.prefix_delta[start_idx]
+
+    def price_delta(self, event_ts: datetime, lookback: timedelta) -> float | None:
+        current_row = self.match_row(event_ts)
+        if current_row is None or current_row.price is None:
+            return None
+        boundary_row = self.match_row(event_ts - lookback)
+        if boundary_row is None or boundary_row.price is None:
+            return None
+        return current_row.price - boundary_row.price
+
+    @staticmethod
+    def dist_vwap(price: float | None, vwap: float | None) -> tuple[float | None, float | None, str]:
+        if price is None or vwap is None:
+            return None, None, PRICE_VS_VWAP_AT_OR_UNKNOWN
+        dist = price - vwap
+        if dist > 0:
+            side = PRICE_VS_VWAP_ABOVE
+        elif dist < 0:
+            side = PRICE_VS_VWAP_BELOW
+        else:
+            side = PRICE_VS_VWAP_AT_OR_UNKNOWN
+        return dist, abs(dist), side
+
+    def _index_at_or_before(self, ts: datetime) -> int | None:
+        idx = bisect_right(self.feed_ts, ts) - 1
+        if idx < 0:
+            return None
+        return idx
+
+    def _build_prefix_delta(self) -> list[float]:
+        prefix = [0.0]
+        running = 0.0
+        for row in self.feed_rows:
+            running += (row.buy_qty or 0.0) - (row.sell_qty or 0.0)
+            prefix.append(running)
+        return prefix

--- a/deltascout/delta_analyzer/modules/feed_reader.py
+++ b/deltascout/delta_analyzer/modules/feed_reader.py
@@ -29,5 +29,14 @@ def read_feed_rows(paths: Iterable[Path]) -> list[FeedRow]:
                 price = _to_float(raw_row.get("ClosePrice"))
                 if price is None:
                     price = _to_float(raw_row.get("AvgPrice"))
-                rows.append(FeedRow(ts=ts, price=price, row=raw_row, source_file=path.name))
+                rows.append(
+                    FeedRow(
+                        ts=ts,
+                        price=price,
+                        buy_qty=_to_float(raw_row.get("BuyQty")),
+                        sell_qty=_to_float(raw_row.get("SellQty")),
+                        row=raw_row,
+                        source_file=path.name,
+                    )
+                )
     return sorted(rows, key=lambda item: item.ts)

--- a/deltascout/delta_analyzer/types.py
+++ b/deltascout/delta_analyzer/types.py
@@ -25,6 +25,8 @@ class NormalizedEvent:
 class FeedRow:
     ts: datetime
     price: float | None
+    buy_qty: float | None
+    sell_qty: float | None
     row: dict[str, Any]
     source_file: str
 
@@ -44,6 +46,32 @@ class EventsBaseRow:
     matched_feed_ts: datetime | None
     source_file: str
     terminal_decision_present: bool
+
+
+@dataclass(frozen=True)
+class EventsContextRow:
+    ts: datetime
+    event_type: str
+    kind: str | None
+    reject_reason: str | None
+    delta: float | None
+    vol: float | None
+    imb: float | None
+    price: float | None
+    vwap: float | None
+    poc: float | None
+    matched_feed_ts: datetime | None
+    source_file: str
+    terminal_decision_present: bool
+    cum_delta_24h: float | None
+    cum_delta_180m: float | None
+    cum_delta_60m: float | None
+    cum_delta_utc_day: float | None
+    ret_15m: float | None
+    ret_60m: float | None
+    dist_vwap: float | None
+    abs_dist_vwap: float | None
+    price_vs_vwap_side: str
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
### Motivation

- Extend the Phase 1 research foundation with a narrow Phase 2 context layer that attaches backward-looking multi-horizon flow and price context to each event while preserving Phase 1 contracts and avoiding production logic changes. 
- Provide honest, rolling cumulative-delta windows and simple backward-looking price deltas to support future setup discovery without adding trend/EMA/regime/outcome logic. 

### Description

- Add a typed `EventsContextRow` and minimal feed-type extensions (`buy_qty`, `sell_qty`) in `deltascout/delta_analyzer/types.py` and extend feed normalization to capture `BuyQty`/`SellQty` in `modules/feed_reader.py`. 
- Implement `FeedContextIndex` in `modules/context_features.py` which indexes feed rows, builds a prefix-sum over `BuyQty - SellQty`, and exposes `rolling_cum_delta`, `utc_day_cum_delta`, `price_delta`, and `dist_vwap` routines. 
- Implement `build_events_context_dataset(...)` in `modules/build_events_context.py` which composes on top of Phase 1 `events_base` rows to add `cum_delta_24h`, `cum_delta_180m`, `cum_delta_60m`, `cum_delta_utc_day`, `ret_15m`, `ret_60m`, `dist_vwap`, `abs_dist_vwap`, and `price_vs_vwap_side`. 
- Wire the new builder into the CLI (`cli.py`) with a `--dataset {events_base,events_context}` switch (default `events_context`), add concise context-coverage reporting, and document Phase 2 in `README.md` and a new `Delta_Analyzer_Phase2_Spec.md`. 

### Testing

- Ran `python -m deltascout.delta_analyzer.cli` (default `events_context`) which executed successfully and printed a concise summary including `events_context_rows` and context non-null coverage. 
- Ran `python -m deltascout.delta_analyzer.cli --dataset events_base` which executed successfully and printed the Phase 1 summary. 
- Ran `python -m compileall deltascout/delta_analyzer` which completed successfully and confirmed modules compile.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc5193f8548323b4f30166e98452ee)