### PR TITLE
Fix Phase 2 context math: continuous rolling windows, true-UTC day, and honest missing-flow

### DIFF
--- a/deltascout/delta_analyzer/Delta_Analyzer_Phase2_Spec.md
+++ b/deltascout/delta_analyzer/Delta_Analyzer_Phase2_Spec.md
@@ -67,6 +67,8 @@ For each event timestamp `event_ts`, rolling windows include all feed rows where
 - `feed_ts <= event_ts`
 - `feed_ts` is inside the requested lookback duration
 
+Feed rows must be read as one merged, timestamp-sorted stream across all discovered CSV files. CSV file boundaries are not time boundaries, so early rows in one file may still consume tail history from the prior file/day when it falls inside the requested lookback window.
+
 Fields:
 
 - `cum_delta_24h`: rolling cumulative delta over the last 24 hours ending at `event_ts`
@@ -75,9 +77,11 @@ Fields:
 
 If full history is not available, compute with whatever feed rows exist in the window. Do not pad or extrapolate.
 
+If any feed row inside the requested rolling window has missing `BuyQty` or `SellQty`, cumulative delta for that window must be `null`. Unknown flow must not be silently coerced to `0.0`.
+
 ### UTC day cumulative delta reference
 
-- `cum_delta_utc_day`: cumulative delta from `00:00 UTC` on the event date through `event_ts`
+- `cum_delta_utc_day`: cumulative delta from the true `00:00 UTC` boundary on the event date through `event_ts`
 
 This field is a reference frame and must remain distinct from `cum_delta_24h`.
 

--- a/deltascout/delta_analyzer/README.md
+++ b/deltascout/delta_analyzer/README.md
@@ -31,7 +31,7 @@ Phase 2 adds `events_context`, a research-only extension of `events_base` that r
 
 Phase 2 currently adds:
 
-- rolling cumulative delta over `24h`, `180m`, and `60m`
+- rolling cumulative delta over `24h`, `180m`, and `60m` using the full merged feed history across all discovered CSV files
 - UTC-day cumulative delta as an explicit reference frame (`cum_delta_utc_day`)
 - backward-looking price deltas over `15m` and `60m`
 - event-price distance from VWAP
@@ -39,8 +39,10 @@ Phase 2 currently adds:
 Important naming rule:
 
 - `cum_delta_24h` means rolling cumulative delta over the last 24 hours ending at the event timestamp
-- `cum_delta_utc_day` means cumulative delta from `00:00 UTC` to the event timestamp
-- these two fields must remain distinct and are not interchangeable
+- `cum_delta_24h`, `cum_delta_180m`, and `cum_delta_60m` are computed from one continuous, globally sorted feed stream across all discovered CSV files; early rows can therefore reuse prior-file / prior-day tail history when it exists
+- `cum_delta_utc_day` means cumulative delta from the true `00:00 UTC` boundary to the event timestamp, even when `event_ts` carries a non-UTC timezone offset
+- if any feed row inside the requested cumulative-delta window has missing `BuyQty` or `SellQty`, the cumulative delta field is `null` rather than silently zero-filling unknown flow
+- these fields must remain distinct and are not interchangeable
 
 The `ret_15m` and `ret_60m` fields are simple backward-looking price differences, not percentage returns.
 

--- a/deltascout/delta_analyzer/modules/build_events_context.py
+++ b/deltascout/delta_analyzer/modules/build_events_context.py
@@ -12,8 +12,9 @@ def build_events_context_dataset(
 ) -> list[EventsContextRow]:
     """Extend Phase 1 rows with backward-looking flow and price context.
 
-    Rolling windows use all available feed rows inside each lookback window and do
-    not pad missing history; partial history is preserved as-is for honest research.
+    Rolling windows use the globally merged, timestamp-sorted feed history across
+    all discovered feed files. They do not reset at file/day boundaries, do not pad
+    missing history, and return None when the requested window includes unknown flow.
     """
 
     context_index = FeedContextIndex(feed_rows)

--- a/deltascout/delta_analyzer/modules/context_features.py
+++ b/deltascout/delta_analyzer/modules/context_features.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from bisect import bisect_right
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from ..types import FeedRow
 
@@ -11,12 +11,13 @@ PRICE_VS_VWAP_BELOW = "below"
 
 
 class FeedContextIndex:
-    """Index feed rows once so research datasets can reuse consistent context math."""
+    """Index globally merged feed rows so Phase 2 windows stay continuous across files."""
 
     def __init__(self, feed_rows: list[FeedRow]):
+        # Feed rows are treated as one merged UTC timeline across all source files.
         self.feed_rows = sorted(feed_rows, key=lambda item: item.ts)
         self.feed_ts = [row.ts for row in self.feed_rows]
-        self.prefix_delta = self._build_prefix_delta()
+        self.prefix_delta, self.prefix_unknown = self._build_prefix_flow_state()
 
     def match_row(self, event_ts: datetime) -> FeedRow | None:
         idx = self._index_at_or_before(event_ts)
@@ -30,14 +31,18 @@ class FeedContextIndex:
             return None
         start_boundary = event_ts - lookback
         start_idx = bisect_right(self.feed_ts, start_boundary - timedelta(microseconds=1))
+        if self.prefix_unknown[end_idx + 1] - self.prefix_unknown[start_idx] > 0:
+            return None
         return self.prefix_delta[end_idx + 1] - self.prefix_delta[start_idx]
 
     def utc_day_cum_delta(self, event_ts: datetime) -> float | None:
         end_idx = self._index_at_or_before(event_ts)
         if end_idx is None:
             return None
-        day_start = event_ts.replace(hour=0, minute=0, second=0, microsecond=0)
+        day_start = self._utc_day_start(event_ts)
         start_idx = bisect_right(self.feed_ts, day_start - timedelta(microseconds=1))
+        if self.prefix_unknown[end_idx + 1] - self.prefix_unknown[start_idx] > 0:
+            return None
         return self.prefix_delta[end_idx + 1] - self.prefix_delta[start_idx]
 
     def price_delta(self, event_ts: datetime, lookback: timedelta) -> float | None:
@@ -68,10 +73,22 @@ class FeedContextIndex:
             return None
         return idx
 
-    def _build_prefix_delta(self) -> list[float]:
-        prefix = [0.0]
-        running = 0.0
+    @staticmethod
+    def _utc_day_start(ts: datetime) -> datetime:
+        if ts.tzinfo is None:
+            return ts.replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
+        return ts.astimezone(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+
+    def _build_prefix_flow_state(self) -> tuple[list[float], list[int]]:
+        prefix_delta = [0.0]
+        prefix_unknown = [0]
+        running_delta = 0.0
+        running_unknown = 0
         for row in self.feed_rows:
-            running += (row.buy_qty or 0.0) - (row.sell_qty or 0.0)
-            prefix.append(running)
-        return prefix
+            if row.buy_qty is None or row.sell_qty is None:
+                running_unknown += 1
+            else:
+                running_delta += row.buy_qty - row.sell_qty
+            prefix_delta.append(running_delta)
+            prefix_unknown.append(running_unknown)
+        return prefix_delta, prefix_unknown

--- a/tests/offline/test_delta_analyzer_phase2.py
+++ b/tests/offline/test_delta_analyzer_phase2.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from deltascout.delta_analyzer.modules.context_features import FeedContextIndex
+from deltascout.delta_analyzer.types import FeedRow
+
+
+def _feed_row(ts: datetime, *, buy_qty: float | None, sell_qty: float | None, price: float = 0.0, source_file: str) -> FeedRow:
+    return FeedRow(
+        ts=ts,
+        price=price,
+        buy_qty=buy_qty,
+        sell_qty=sell_qty,
+        row={},
+        source_file=source_file,
+    )
+
+
+def test_rolling_windows_use_continuous_history_across_feed_files():
+    index = FeedContextIndex(
+        [
+            _feed_row(datetime(2026, 1, 1, 23, 30, tzinfo=timezone.utc), buy_qty=5.0, sell_qty=1.0, source_file='day1.csv'),
+            _feed_row(datetime(2026, 1, 2, 0, 10, tzinfo=timezone.utc), buy_qty=2.0, sell_qty=1.0, source_file='day2.csv'),
+        ]
+    )
+
+    assert index.feed_rows[0].source_file == 'day1.csv'
+    assert index.feed_rows[1].source_file == 'day2.csv'
+    assert index.rolling_cum_delta(datetime(2026, 1, 2, 0, 15, tzinfo=timezone.utc), timedelta(minutes=60)) == 5.0
+
+
+def test_utc_day_boundary_uses_true_utc_midnight_not_local_midnight():
+    index = FeedContextIndex(
+        [
+            _feed_row(datetime(2026, 1, 1, 22, 30, tzinfo=timezone.utc), buy_qty=10.0, sell_qty=3.0, source_file='day1.csv'),
+            _feed_row(datetime(2026, 1, 2, 0, 30, tzinfo=timezone.utc), buy_qty=4.0, sell_qty=1.0, source_file='day2.csv'),
+        ]
+    )
+
+    event_ts = datetime(2026, 1, 2, 1, 0, tzinfo=timezone(timedelta(hours=2)))
+
+    assert event_ts.astimezone(timezone.utc) == datetime(2026, 1, 1, 23, 0, tzinfo=timezone.utc)
+    assert index.utc_day_cum_delta(event_ts) == 7.0
+
+
+def test_missing_flow_inside_window_returns_none_instead_of_zero_fill():
+    index = FeedContextIndex(
+        [
+            _feed_row(datetime(2026, 1, 2, 0, 0, tzinfo=timezone.utc), buy_qty=3.0, sell_qty=1.0, source_file='day2.csv'),
+            _feed_row(datetime(2026, 1, 2, 0, 30, tzinfo=timezone.utc), buy_qty=None, sell_qty=2.0, source_file='day2.csv'),
+            _feed_row(datetime(2026, 1, 2, 1, 0, tzinfo=timezone.utc), buy_qty=4.0, sell_qty=1.0, source_file='day2.csv'),
+        ]
+    )
+
+    event_ts = datetime(2026, 1, 2, 1, 0, tzinfo=timezone.utc)
+
+    assert index.rolling_cum_delta(event_ts, timedelta(hours=24)) is None
+    assert index.rolling_cum_delta(event_ts, timedelta(minutes=180)) is None
+    assert index.rolling_cum_delta(event_ts, timedelta(minutes=60)) is None
+    assert index.utc_day_cum_delta(event_ts) is None
+    assert index.rolling_cum_delta(event_ts, timedelta(minutes=20)) == 3.0


### PR DESCRIPTION
### Motivation
- Fix Phase 2 context math so rolling cumulative-delta windows do not treat individual feed CSV files as time boundaries and so UTC-day math uses a true UTC boundary.  
- Ensure missing per-row flow (`BuyQty`/`SellQty`) is treated as unknown (not silently zero-filled) and that cumulative-delta windows reflect that honest missingness.  
- Keep scope minimal and confined to `deltascout/delta_analyzer` (no production DeltaScout changes).  

### Description
- Use a globally merged, timestamp-sorted feed stream for all rolling windows by updating `FeedContextIndex` in `deltascout/delta_analyzer/modules/context_features.py` to operate on the full merged `feed_rows` and prefix state.  
- Treat rows with `buy_qty is None` or `sell_qty is None` as unknown flow: prefix tracking now includes an `unknown` count and any window containing unknown rows returns `None` for cumulative delta instead of coercing missing values to `0.0`.  
- Fix `cum_delta_utc_day` to compute from the true `00:00 UTC` boundary (convert `event_ts` to UTC midnight) rather than zeroing the local timezone clock.  
- Clarified dataset builder docstring in `deltascout/delta_analyzer/modules/build_events_context.py` and updated `README.md` and `Delta_Analyzer_Phase2_Spec.md` to document continuous merged feed history, true-UTC-day semantics, and honest missing-flow behavior.  
- Added synthetic contract tests `tests/offline/test_delta_analyzer_phase2.py` that validate: continuous history across feed-file boundaries, true-UTC-day boundary behavior, and that missing `BuyQty`/`SellQty` inside a window produces `None`.  
- Files changed: `deltascout/delta_analyzer/modules/context_features.py`, `deltascout/delta_analyzer/modules/build_events_context.py`, `deltascout/delta_analyzer/README.md`, `deltascout/delta_analyzer/Delta_Analyzer_Phase2_Spec.md`, and `tests/offline/test_delta_analyzer_phase2.py`.

### Testing
- Ran the new synthetic contract tests with `PYTHONPATH=. pytest -q tests/offline/test_delta_analyzer_phase2.py`, and all tests passed (`3 passed`).  
- Tests cover the three requested cases: (1) rolling windows use prior-day tail history across feed-file boundaries, (2) `cum_delta_utc_day` uses true UTC midnight rather than local midnight, and (3) missing `BuyQty`/`SellQty` inside a rolling window causes cumulative delta to be `None` (not zero-filled).  
- No other automated tests were modified; change is scoped to research-layer Phase 2 logic and docs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc6347f310832390eae93c4f1d3aee)