### PR TITLE
Remove cum_delta_utc_day from Delta Analyzer Phase 2

### DIFF
--- a/deltascout/delta_analyzer/Delta_Analyzer_Phase2_Spec.md
+++ b/deltascout/delta_analyzer/Delta_Analyzer_Phase2_Spec.md
@@ -41,7 +41,6 @@ Each `events_context` row contains all `events_base` fields plus:
 - `cum_delta_24h`
 - `cum_delta_180m`
 - `cum_delta_60m`
-- `cum_delta_utc_day`
 - `ret_15m`
 - `ret_60m`
 - `dist_vwap`
@@ -78,12 +77,6 @@ Fields:
 If full history is not available, compute with whatever feed rows exist in the window. Do not pad or extrapolate.
 
 If any feed row inside the requested rolling window has missing `BuyQty` or `SellQty`, cumulative delta for that window must be `null`. Unknown flow must not be silently coerced to `0.0`.
-
-### UTC day cumulative delta reference
-
-- `cum_delta_utc_day`: cumulative delta from the true `00:00 UTC` boundary on the event date through `event_ts`
-
-This field is a reference frame and must remain distinct from `cum_delta_24h`.
 
 ### Return fields
 
@@ -127,9 +120,8 @@ Phase 2 is acceptable if:
 
 1. `events_context` builds from local research materials
 2. required context fields are attached when underlying data exists
-3. `cum_delta_24h` is clearly distinct from `cum_delta_utc_day`
-4. `cum_delta_60m` and `cum_delta_180m` are rolling windows ending at the event timestamp
-5. VWAP distance fields are present
-6. backward-looking price context fields are present
-7. the CLI runs successfully and prints a concise summary
-8. no production DeltaScout logic is modified
+3. `cum_delta_60m` and `cum_delta_180m` are rolling windows ending at the event timestamp
+4. VWAP distance fields are present
+5. backward-looking price context fields are present
+6. the CLI runs successfully and prints a concise summary
+7. no production DeltaScout logic is modified

--- a/deltascout/delta_analyzer/README.md
+++ b/deltascout/delta_analyzer/README.md
@@ -32,7 +32,6 @@ Phase 2 adds `events_context`, a research-only extension of `events_base` that r
 Phase 2 currently adds:
 
 - rolling cumulative delta over `24h`, `180m`, and `60m` using the full merged feed history across all discovered CSV files
-- UTC-day cumulative delta as an explicit reference frame (`cum_delta_utc_day`)
 - backward-looking price deltas over `15m` and `60m`
 - event-price distance from VWAP
 
@@ -40,7 +39,6 @@ Important naming rule:
 
 - `cum_delta_24h` means rolling cumulative delta over the last 24 hours ending at the event timestamp
 - `cum_delta_24h`, `cum_delta_180m`, and `cum_delta_60m` are computed from one continuous, globally sorted feed stream across all discovered CSV files; early rows can therefore reuse prior-file / prior-day tail history when it exists
-- `cum_delta_utc_day` means cumulative delta from the true `00:00 UTC` boundary to the event timestamp, even when `event_ts` carries a non-UTC timezone offset
 - if any feed row inside the requested cumulative-delta window has missing `BuyQty` or `SellQty`, the cumulative delta field is `null` rather than silently zero-filling unknown flow
 - these fields must remain distinct and are not interchangeable
 

--- a/deltascout/delta_analyzer/cli.py
+++ b/deltascout/delta_analyzer/cli.py
@@ -18,7 +18,6 @@ CONTEXT_COVERAGE_FIELDS = (
     "cum_delta_24h",
     "cum_delta_180m",
     "cum_delta_60m",
-    "cum_delta_utc_day",
     "ret_15m",
     "ret_60m",
     "dist_vwap",

--- a/deltascout/delta_analyzer/modules/build_events_context.py
+++ b/deltascout/delta_analyzer/modules/build_events_context.py
@@ -40,7 +40,6 @@ def build_events_context_dataset(
                 cum_delta_24h=context_index.rolling_cum_delta(row.ts, timedelta(hours=24)),
                 cum_delta_180m=context_index.rolling_cum_delta(row.ts, timedelta(minutes=180)),
                 cum_delta_60m=context_index.rolling_cum_delta(row.ts, timedelta(minutes=60)),
-                cum_delta_utc_day=context_index.utc_day_cum_delta(row.ts),
                 ret_15m=context_index.price_delta(row.ts, timedelta(minutes=15)),
                 ret_60m=context_index.price_delta(row.ts, timedelta(minutes=60)),
                 dist_vwap=dist_vwap,

--- a/deltascout/delta_analyzer/modules/context_features.py
+++ b/deltascout/delta_analyzer/modules/context_features.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from bisect import bisect_right
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 
 from ..types import FeedRow
 
@@ -35,16 +35,6 @@ class FeedContextIndex:
             return None
         return self.prefix_delta[end_idx + 1] - self.prefix_delta[start_idx]
 
-    def utc_day_cum_delta(self, event_ts: datetime) -> float | None:
-        end_idx = self._index_at_or_before(event_ts)
-        if end_idx is None:
-            return None
-        day_start = self._utc_day_start(event_ts)
-        start_idx = bisect_right(self.feed_ts, day_start - timedelta(microseconds=1))
-        if self.prefix_unknown[end_idx + 1] - self.prefix_unknown[start_idx] > 0:
-            return None
-        return self.prefix_delta[end_idx + 1] - self.prefix_delta[start_idx]
-
     def price_delta(self, event_ts: datetime, lookback: timedelta) -> float | None:
         current_row = self.match_row(event_ts)
         if current_row is None or current_row.price is None:
@@ -72,12 +62,6 @@ class FeedContextIndex:
         if idx < 0:
             return None
         return idx
-
-    @staticmethod
-    def _utc_day_start(ts: datetime) -> datetime:
-        if ts.tzinfo is None:
-            return ts.replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
-        return ts.astimezone(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
 
     def _build_prefix_flow_state(self) -> tuple[list[float], list[int]]:
         prefix_delta = [0.0]

--- a/deltascout/delta_analyzer/types.py
+++ b/deltascout/delta_analyzer/types.py
@@ -66,7 +66,6 @@ class EventsContextRow:
     cum_delta_24h: float | None
     cum_delta_180m: float | None
     cum_delta_60m: float | None
-    cum_delta_utc_day: float | None
     ret_15m: float | None
     ret_60m: float | None
     dist_vwap: float | None

--- a/deltascout/test/test_delta_analyzer_phase2_contracts.py
+++ b/deltascout/test/test_delta_analyzer_phase2_contracts.py
@@ -93,19 +93,6 @@ def test_rolling_cum_delta_windows_sum_buy_minus_sell_inside_lookback():
     assert index.rolling_cum_delta(event_ts, timedelta(hours=24)) == 9.0
 
 
-def test_utc_day_cum_delta_is_distinct_from_rolling_24h():
-    index = FeedContextIndex(
-        [
-            _feed("2026-01-01T23:50:00", price=100.0, buy=7.0, sell=1.0),   # +6, previous UTC day
-            _feed("2026-01-02T00:10:00", price=101.0, buy=2.0, sell=1.0),   # +1, current UTC day
-            _feed("2026-01-02T00:20:00", price=102.0, buy=4.0, sell=1.0),   # +3, current UTC day
-        ]
-    )
-    event_ts = _dt("2026-01-02T00:30:00")
-
-    assert index.utc_day_cum_delta(event_ts) == 4.0
-    assert index.rolling_cum_delta(event_ts, timedelta(hours=24)) == 10.0
-
 
 def test_price_delta_uses_backward_boundary_match_and_returns_absolute_difference():
     index = FeedContextIndex(
@@ -148,7 +135,6 @@ def test_build_events_context_dataset_attaches_expected_phase2_fields():
     assert len(rows) == 1
     row = rows[0]
     assert row.cum_delta_60m == 8.0
-    assert row.cum_delta_utc_day == 6.0
     assert row.ret_15m == 3.0
     assert row.ret_60m is None
     assert row.dist_vwap == 1.0

--- a/tests/offline/test_delta_analyzer_phase2.py
+++ b/tests/offline/test_delta_analyzer_phase2.py
@@ -30,19 +30,6 @@ def test_rolling_windows_use_continuous_history_across_feed_files():
     assert index.rolling_cum_delta(datetime(2026, 1, 2, 0, 15, tzinfo=timezone.utc), timedelta(minutes=60)) == 5.0
 
 
-def test_utc_day_boundary_uses_true_utc_midnight_not_local_midnight():
-    index = FeedContextIndex(
-        [
-            _feed_row(datetime(2026, 1, 1, 22, 30, tzinfo=timezone.utc), buy_qty=10.0, sell_qty=3.0, source_file='day1.csv'),
-            _feed_row(datetime(2026, 1, 2, 0, 30, tzinfo=timezone.utc), buy_qty=4.0, sell_qty=1.0, source_file='day2.csv'),
-        ]
-    )
-
-    event_ts = datetime(2026, 1, 2, 1, 0, tzinfo=timezone(timedelta(hours=2)))
-
-    assert event_ts.astimezone(timezone.utc) == datetime(2026, 1, 1, 23, 0, tzinfo=timezone.utc)
-    assert index.utc_day_cum_delta(event_ts) == 7.0
-
 
 def test_missing_flow_inside_window_returns_none_instead_of_zero_fill():
     index = FeedContextIndex(
@@ -58,5 +45,4 @@ def test_missing_flow_inside_window_returns_none_instead_of_zero_fill():
     assert index.rolling_cum_delta(event_ts, timedelta(hours=24)) is None
     assert index.rolling_cum_delta(event_ts, timedelta(minutes=180)) is None
     assert index.rolling_cum_delta(event_ts, timedelta(minutes=60)) is None
-    assert index.utc_day_cum_delta(event_ts) is None
     assert index.rolling_cum_delta(event_ts, timedelta(minutes=20)) == 3.0


### PR DESCRIPTION
### Motivation

- `cum_delta_utc_day` is not part of the Phase 2 research priority and introduced timezone handling complexity that is unnecessary for current rolling-window focus.
- Keep Phase 2 implementation minimal and focused on rolling cumulative windows, backward price deltas, and VWAP-distance fields.

### Description

- Remove the `cum_delta_utc_day` field from the `EventsContextRow` schema in `deltascout/delta_analyzer/types.py`.
- Stop building/exporting UTC-day context in `build_events_context_dataset(...)` by removing the `cum_delta_utc_day` attachment in `deltascout/delta_analyzer/modules/build_events_context.py`.
- Delete the UTC-day cumulative-delta implementation and its timezone helper/imports from `FeedContextIndex` in `deltascout/delta_analyzer/modules/context_features.py` (remove `utc_day_cum_delta`, `_utc_day_start`, and related `timezone` usage).
- Remove `cum_delta_utc_day` from CLI coverage reporting and update Phase 2 docs/spec to no longer mention UTC-day cumulative delta, and remove the now-redundant UTC-day test assertions from Phase 2 tests.

### Testing

- Ran unit tests for Phase 2 contracts and offline checks with `pytest -q deltascout/test/test_delta_analyzer_phase2_contracts.py tests/offline/test_delta_analyzer_phase2.py` and all tests passed (`7 passed`).
- Verified CLI runs and summary output with `python -m deltascout.delta_analyzer.cli --dataset events_context`, which completed successfully and printed the context coverage without `cum_delta_utc_day`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcebaa80a48323b4ce9c29bf206184)