### PR TITLE
Add Delta Analyzer Phase 2.5 review-builder skeleton

### DIFF
--- a/deltascout/delta_analyzer/README.md
+++ b/deltascout/delta_analyzer/README.md
@@ -70,6 +70,9 @@ Optional overrides:
 python -m deltascout.delta_analyzer.cli --archive-glob "deltascout/research_material/raw_archive/*.jsonl" --feed-glob "deltascout/research_material/raw_feed/*.csv"
 python -m deltascout.delta_analyzer.cli --dataset events_base
 python -m deltascout.delta_analyzer.cli --dataset events_context
+python -m deltascout.delta_analyzer.cli --build-review --date YYYY-MM-DD --input-root /data/archive/datasets --output-root /data/archive/datasets
 ```
 
 The default globs already point to the local research-material folder copied for DeltaScout research.
+
+The review-builder mode is the Phase 2.5 skeleton only: it reads daily `events_context` plus optional `close_outcomes`, then writes accepted/reject review tables and a deterministic Markdown summary under `reviews/YYYY-MM-DD/`.

--- a/deltascout/delta_analyzer/cli.py
+++ b/deltascout/delta_analyzer/cli.py
@@ -9,11 +9,13 @@ from .config import DEFAULT_ARCHIVE_GLOB, DEFAULT_FEED_GLOB
 from .modules.archive_reader import read_archive_events
 from .modules.build_events_base import build_events_base_dataset
 from .modules.build_events_context import build_events_context_dataset
+from .modules.build_review_tables import ReviewBuildError, build_daily_review_package
 from .modules.feed_reader import read_feed_rows
 from .modules.integrity_checks import run_integrity_checks
 
 
 DATASET_CHOICES = ("events_base", "events_context")
+DEFAULT_DATASET_ROOT = "/data/archive/datasets"
 CONTEXT_COVERAGE_FIELDS = (
     "cum_delta_24h",
     "cum_delta_180m",
@@ -34,6 +36,10 @@ def build_parser() -> argparse.ArgumentParser:
         default="events_context",
         help="Highest dataset layer to build. events_context also builds events_base.",
     )
+    parser.add_argument("--build-review", action="store_true", help="Build Phase 2.5 daily review artifacts from dataset CSV inputs.")
+    parser.add_argument("--date", help="UTC date for review build mode in YYYY-MM-DD format.")
+    parser.add_argument("--input-root", default=DEFAULT_DATASET_ROOT, help="Dataset root for review-builder inputs.")
+    parser.add_argument("--output-root", default=DEFAULT_DATASET_ROOT, help="Dataset root for review-builder outputs.")
     return parser
 
 
@@ -43,6 +49,21 @@ def _expand_glob(pattern: str) -> list[Path]:
 
 def main() -> None:
     args = build_parser().parse_args()
+    if args.build_review:
+        if not args.date:
+            raise SystemExit("--date is required with --build-review")
+        try:
+            result = build_daily_review_package(args.date, args.input_root, args.output_root)
+        except ReviewBuildError as exc:
+            raise SystemExit(str(exc)) from exc
+        print("Delta Analyzer Review Build")
+        print(f"processed_date={result.date}")
+        print(f"accepted_rows={result.accepted_count}")
+        print(f"reject_rows={result.reject_count}")
+        print(f"matched_accepted_close_rows={result.matched_close_count}")
+        print(f"output_dir={result.output_dir}")
+        return
+
     archive_files = _expand_glob(args.archive_glob)
     feed_files = _expand_glob(args.feed_glob)
 

--- a/deltascout/delta_analyzer/modules/build_review_tables.py
+++ b/deltascout/delta_analyzer/modules/build_review_tables.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ACCEPTED_EVENT_TYPE = "PEAK_EMIT"
+REJECT_EVENT_TYPES = (
+    "CANDIDATE_COMPARISON_REJECT",
+    "CANDIDATE_GATE_REJECT",
+)
+BASE_FIELDS = (
+    "ts",
+    "day",
+    "event_type",
+    "kind",
+    "reject_reason",
+    "delta",
+    "vol",
+    "imb",
+    "price",
+    "vwap",
+    "poc",
+    "matched_feed_ts",
+    "source_file",
+    "terminal_decision_present",
+)
+CONTEXT_FIELDS = (
+    "cum_delta_24h",
+    "cum_delta_180m",
+    "cum_delta_60m",
+    "ret_15m",
+    "ret_60m",
+    "dist_vwap",
+    "abs_dist_vwap",
+    "price_vs_vwap_side",
+)
+ACCEPTED_JOIN_FIELDS = (
+    "join_status",
+    "join_confidence",
+    "close_ts",
+    "close_reason",
+    "entry",
+    "side",
+)
+
+
+class ReviewBuildError(RuntimeError):
+    """Raised when deterministic review-builder inputs are missing or invalid."""
+
+
+@dataclass(frozen=True)
+class ReviewBuildResult:
+    date: str
+    accepted_count: int
+    reject_count: int
+    matched_close_count: int
+    output_dir: Path
+    accepted_path: Path
+    reject_path: Path
+    summary_path: Path
+
+
+def build_daily_review_package(date: str, input_root: Path | str, output_root: Path | str) -> ReviewBuildResult:
+    input_root = Path(input_root)
+    output_root = Path(output_root)
+
+    events_context_rows = _load_required_csv(input_root / f"events_context_{date}.csv", required_name="events_context")
+    close_outcome_rows = _load_optional_csv(input_root / f"close_outcomes_{date}.csv")
+    close_outcomes_by_key = _index_close_outcomes(close_outcome_rows)
+
+    accepted_rows = build_accepted_event_context_rows(events_context_rows, close_outcomes_by_key)
+    reject_rows = build_reject_event_context_rows(events_context_rows)
+
+    review_dir = output_root / "reviews" / date
+    review_dir.mkdir(parents=True, exist_ok=True)
+
+    accepted_path = review_dir / f"accepted_event_context_{date}.csv"
+    reject_path = review_dir / f"reject_event_context_{date}.csv"
+    summary_path = review_dir / f"daily_review_summary_{date}.md"
+
+    _write_csv(accepted_path, accepted_rows, BASE_FIELDS + CONTEXT_FIELDS + ACCEPTED_JOIN_FIELDS)
+    _write_csv(reject_path, reject_rows, _ordered_reject_fields(reject_rows))
+    summary_path.write_text(_build_summary(date, accepted_rows, reject_rows, accepted_path, reject_path, summary_path), encoding="utf-8")
+
+    return ReviewBuildResult(
+        date=date,
+        accepted_count=len(accepted_rows),
+        reject_count=len(reject_rows),
+        matched_close_count=sum(1 for row in accepted_rows if row.get("join_status")),
+        output_dir=review_dir,
+        accepted_path=accepted_path,
+        reject_path=reject_path,
+        summary_path=summary_path,
+    )
+
+
+def build_accepted_event_context_rows(
+    events_context_rows: list[dict[str, str]],
+    close_outcomes_by_key: dict[tuple[str, str], dict[str, str]],
+) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    for row in events_context_rows:
+        if row.get("event_type") != ACCEPTED_EVENT_TYPE:
+            continue
+        output_row = {field: row.get(field, "") for field in BASE_FIELDS + CONTEXT_FIELDS}
+        close_row = close_outcomes_by_key.get((_normalize_ts_key(row.get("ts")), _normalize_kind_key(row.get("kind"))))
+        for field in ACCEPTED_JOIN_FIELDS:
+            output_row[field] = close_row.get(field, "") if close_row else ""
+        rows.append(output_row)
+    return rows
+
+
+def build_reject_event_context_rows(events_context_rows: list[dict[str, str]]) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    for row in events_context_rows:
+        if row.get("event_type") in REJECT_EVENT_TYPES:
+            rows.append(dict(row))
+    return rows
+
+
+def _ordered_reject_fields(rows: list[dict[str, str]]) -> tuple[str, ...]:
+    preferred = list(BASE_FIELDS + CONTEXT_FIELDS)
+    extras: list[str] = []
+    for row in rows:
+        for key in row:
+            if key not in preferred and key not in extras:
+                extras.append(key)
+    return tuple(preferred + extras)
+
+
+def _load_required_csv(path: Path, *, required_name: str) -> list[dict[str, str]]:
+    if not path.exists():
+        raise ReviewBuildError(f"missing {required_name} input: {path}")
+    return _load_csv(path)
+
+
+def _load_optional_csv(path: Path) -> list[dict[str, str]]:
+    if not path.exists():
+        return []
+    return _load_csv(path)
+
+
+def _load_csv(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def _index_close_outcomes(rows: list[dict[str, str]]) -> dict[tuple[str, str], dict[str, str]]:
+    indexed: dict[tuple[str, str], dict[str, str]] = {}
+    for row in rows:
+        key = (_normalize_ts_key(row.get("peak_ts")), _normalize_kind_key(row.get("peak_kind")))
+        if not key[0]:
+            continue
+        indexed.setdefault(key, {field: row.get(field, "") for field in ACCEPTED_JOIN_FIELDS})
+    return indexed
+
+
+def _normalize_ts_key(value: Any) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if not text:
+        return ""
+    normalized = text.replace("Z", "+00:00")
+    try:
+        ts = datetime.fromisoformat(normalized)
+    except ValueError:
+        return text
+    if ts.tzinfo is not None:
+        ts = ts.astimezone(timezone.utc)
+    return ts.replace(microsecond=0).isoformat()
+
+
+def _normalize_kind_key(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _write_csv(path: Path, rows: list[dict[str, str]], fieldnames: tuple[str, ...]) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({field: row.get(field, "") for field in fieldnames})
+
+
+def _build_summary(
+    date: str,
+    accepted_rows: list[dict[str, str]],
+    reject_rows: list[dict[str, str]],
+    accepted_path: Path,
+    reject_path: Path,
+    summary_path: Path,
+) -> str:
+    matched_close_count = sum(1 for row in accepted_rows if row.get("join_status"))
+    reason_counts: dict[str, int] = {}
+    for row in reject_rows:
+        reason = (row.get("reject_reason") or "").strip() or "<missing>"
+        reason_counts[reason] = reason_counts.get(reason, 0) + 1
+
+    lines = [
+        f"# Daily Review Summary {date}",
+        "",
+        f"- processed_date: {date}",
+        f"- accepted_row_count: {len(accepted_rows)}",
+        f"- reject_row_count: {len(reject_rows)}",
+        f"- accepted_with_close_outcomes: {matched_close_count}",
+        "- reject_counts_by_reason:",
+    ]
+    if reason_counts:
+        for reason, count in sorted(reason_counts.items()):
+            lines.append(f"  - {reason}: {count}")
+    else:
+        lines.append("  - <none>: 0")
+    lines.extend(
+        [
+            "- files_created:",
+            f"  - {accepted_path.name}",
+            f"  - {reject_path.name}",
+            f"  - {summary_path.name}",
+            "",
+        ]
+    )
+    return "\n".join(lines)

--- a/tests/offline/test_delta_analyzer_review_builder.py
+++ b/tests/offline/test_delta_analyzer_review_builder.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+import sys
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from deltascout.delta_analyzer.modules.build_review_tables import build_daily_review_package
+
+
+EVENTS_CONTEXT_FIELDS = [
+    "ts",
+    "day",
+    "event_type",
+    "kind",
+    "reject_reason",
+    "delta",
+    "vol",
+    "imb",
+    "price",
+    "vwap",
+    "poc",
+    "matched_feed_ts",
+    "source_file",
+    "terminal_decision_present",
+    "cum_delta_24h",
+    "cum_delta_180m",
+    "cum_delta_60m",
+    "ret_15m",
+    "ret_60m",
+    "dist_vwap",
+    "abs_dist_vwap",
+    "price_vs_vwap_side",
+]
+
+
+CLOSE_OUTCOME_FIELDS = [
+    "peak_ts",
+    "peak_kind",
+    "join_status",
+    "join_confidence",
+    "close_ts",
+    "close_reason",
+    "entry",
+    "side",
+]
+
+
+def _write_csv(path: Path, fieldnames: list[str], rows: list[dict[str, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+@pytest.fixture
+def dataset_root(tmp_path: Path) -> Path:
+    _write_csv(
+        tmp_path / "events_context_2026-01-02.csv",
+        EVENTS_CONTEXT_FIELDS,
+        [
+            {
+                "ts": "2026-01-02T00:10:00Z",
+                "day": "2026-01-02",
+                "event_type": "PEAK_EMIT",
+                "kind": "long",
+                "reject_reason": "",
+                "delta": "10",
+                "vol": "2",
+                "imb": "0.8",
+                "price": "101",
+                "vwap": "100",
+                "poc": "99",
+                "matched_feed_ts": "2026-01-02T00:10:00Z",
+                "source_file": "archive.jsonl",
+                "terminal_decision_present": "True",
+                "cum_delta_24h": "50",
+                "cum_delta_180m": "12",
+                "cum_delta_60m": "4",
+                "ret_15m": "2",
+                "ret_60m": "3",
+                "dist_vwap": "1",
+                "abs_dist_vwap": "1",
+                "price_vs_vwap_side": "above",
+            },
+            {
+                "ts": "2026-01-02T00:20:00+00:00",
+                "day": "2026-01-02",
+                "event_type": "CANDIDATE_GATE_REJECT",
+                "kind": "short",
+                "reject_reason": "weak_delta",
+                "delta": "-5",
+                "vol": "1",
+                "imb": "-0.4",
+                "price": "99",
+                "vwap": "100",
+                "poc": "98",
+                "matched_feed_ts": "2026-01-02T00:20:00Z",
+                "source_file": "archive.jsonl",
+                "terminal_decision_present": "True",
+                "cum_delta_24h": "40",
+                "cum_delta_180m": "10",
+                "cum_delta_60m": "2",
+                "ret_15m": "-1",
+                "ret_60m": "-2",
+                "dist_vwap": "-1",
+                "abs_dist_vwap": "1",
+                "price_vs_vwap_side": "below",
+            },
+            {
+                "ts": "2026-01-02T00:30:00Z",
+                "day": "2026-01-02",
+                "event_type": "CANDIDATE_COMPARISON_REJECT",
+                "kind": "long",
+                "reject_reason": "comparison_fail",
+                "delta": "7",
+                "vol": "3",
+                "imb": "0.6",
+                "price": "102",
+                "vwap": "101",
+                "poc": "100",
+                "matched_feed_ts": "2026-01-02T00:30:00Z",
+                "source_file": "archive.jsonl",
+                "terminal_decision_present": "True",
+                "cum_delta_24h": "45",
+                "cum_delta_180m": "11",
+                "cum_delta_60m": "3",
+                "ret_15m": "1",
+                "ret_60m": "2",
+                "dist_vwap": "1",
+                "abs_dist_vwap": "1",
+                "price_vs_vwap_side": "above",
+            },
+            {
+                "ts": "2026-01-02T00:40:00Z",
+                "day": "2026-01-02",
+                "event_type": "DELTA_MAX",
+                "kind": "long",
+                "reject_reason": "",
+                "delta": "8",
+                "vol": "4",
+                "imb": "0.7",
+                "price": "103",
+                "vwap": "102",
+                "poc": "101",
+                "matched_feed_ts": "2026-01-02T00:40:00Z",
+                "source_file": "archive.jsonl",
+                "terminal_decision_present": "False",
+                "cum_delta_24h": "46",
+                "cum_delta_180m": "13",
+                "cum_delta_60m": "5",
+                "ret_15m": "2",
+                "ret_60m": "4",
+                "dist_vwap": "1",
+                "abs_dist_vwap": "1",
+                "price_vs_vwap_side": "above",
+            },
+        ],
+    )
+    return tmp_path
+
+
+def test_accepted_table_includes_peak_emit_rows_only(dataset_root: Path, tmp_path: Path):
+    result = build_daily_review_package("2026-01-02", dataset_root, tmp_path)
+
+    with result.accepted_path.open("r", encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+
+    assert len(rows) == 1
+    assert {row["event_type"] for row in rows} == {"PEAK_EMIT"}
+
+
+
+def test_reject_table_includes_only_reject_rows(dataset_root: Path, tmp_path: Path):
+    result = build_daily_review_package("2026-01-02", dataset_root, tmp_path)
+
+    with result.reject_path.open("r", encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+
+    assert len(rows) == 2
+    assert {row["event_type"] for row in rows} == {"CANDIDATE_GATE_REJECT", "CANDIDATE_COMPARISON_REJECT"}
+
+
+
+def test_accepted_table_joins_close_outcomes_on_peak_ts_and_peak_kind(dataset_root: Path, tmp_path: Path):
+    _write_csv(
+        dataset_root / "close_outcomes_2026-01-02.csv",
+        CLOSE_OUTCOME_FIELDS,
+        [
+            {
+                "peak_ts": "2026-01-02 00:10:00+00:00",
+                "peak_kind": "LONG",
+                "join_status": "exact",
+                "join_confidence": "1.0",
+                "close_ts": "2026-01-02T01:00:00Z",
+                "close_reason": "TP1",
+                "entry": "101.25",
+                "side": "LONG",
+            }
+        ],
+    )
+
+    result = build_daily_review_package("2026-01-02", dataset_root, tmp_path)
+    with result.accepted_path.open("r", encoding="utf-8", newline="") as handle:
+        row = next(csv.DictReader(handle))
+
+    assert row["join_status"] == "exact"
+    assert row["join_confidence"] == "1.0"
+    assert row["close_reason"] == "TP1"
+    assert row["entry"] == "101.25"
+    assert row["side"] == "LONG"
+    assert result.matched_close_count == 1
+
+
+
+def test_build_succeeds_without_close_outcomes_and_leaves_join_fields_empty(dataset_root: Path, tmp_path: Path):
+    result = build_daily_review_package("2026-01-02", dataset_root, tmp_path)
+
+    with result.accepted_path.open("r", encoding="utf-8", newline="") as handle:
+        row = next(csv.DictReader(handle))
+
+    assert row["join_status"] == ""
+    assert row["close_ts"] == ""
+    assert row["close_reason"] == ""
+    assert result.matched_close_count == 0
+
+
+
+def test_build_fails_clearly_when_events_context_is_missing(tmp_path: Path):
+    with pytest.raises(RuntimeError, match=r"missing events_context input: .+events_context_2026-01-02\.csv"):
+        build_daily_review_package("2026-01-02", tmp_path, tmp_path)
+
+
+
+def test_markdown_summary_is_created_with_required_counts(dataset_root: Path, tmp_path: Path):
+    _write_csv(
+        dataset_root / "close_outcomes_2026-01-02.csv",
+        CLOSE_OUTCOME_FIELDS,
+        [
+            {
+                "peak_ts": "2026-01-02T00:10:00Z",
+                "peak_kind": "long",
+                "join_status": "exact",
+                "join_confidence": "1.0",
+                "close_ts": "2026-01-02T01:00:00Z",
+                "close_reason": "TP1",
+                "entry": "101.25",
+                "side": "LONG",
+            }
+        ],
+    )
+
+    result = build_daily_review_package("2026-01-02", dataset_root, tmp_path)
+    summary = result.summary_path.read_text(encoding="utf-8")
+
+    assert "processed_date: 2026-01-02" in summary
+    assert "accepted_row_count: 1" in summary
+    assert "reject_row_count: 2" in summary
+    assert "accepted_with_close_outcomes: 1" in summary
+    assert "comparison_fail: 1" in summary
+    assert "weak_delta: 1" in summary
+    assert result.accepted_path.name in summary
+    assert result.reject_path.name in summary
+    assert result.summary_path.name in summary


### PR DESCRIPTION
### Motivation
- Implement the Phase 2.5 review-loop skeleton to turn archived Phase 2 `events_context` into deterministic daily review packages for accepted and rejected candidate review without expanding Phase boundaries. 
- Provide a minimal, auditable join to external `close_outcomes` and a short mechanical summary so research operators can run a single CLI command to produce review artifacts.

### Description
- Add a new review-builder module `deltascout/delta_analyzer/modules/build_review_tables.py` that loads `events_context_YYYY-MM-DD.csv`, optionally `close_outcomes_YYYY-MM-DD.csv`, builds `accepted_event_context_YYYY-MM-DD.csv` (only `PEAK_EMIT`) and `reject_event_context_YYYY-MM-DD.csv` (only `CANDIDATE_COMPARISON_REJECT` and `CANDIDATE_GATE_REJECT`), and writes a deterministic `daily_review_summary_YYYY-MM-DD.md` under `<output_root>/reviews/YYYY-MM-DD/`.
- Implement deterministic close-outcome linkage by normalizing `ts`/`kind` and joining to `peak_ts`/`peak_kind` with second-precision UTC normalization and lowercase kind normalization, leaving join fields empty when no match is found.
- Add CLI integration in `deltascout/delta_analyzer/cli.py` with `--build-review --date YYYY-MM-DD --input-root ... --output-root ...`, fail-loud behavior for missing required inputs, and a concise printed completion summary including counts and output dir.
- Update `deltascout/delta_analyzer/README.md` with a short note about the new review-builder CLI mode and its Phase 2.5 skeleton scope.
- Add focused synthetic tests `tests/offline/test_delta_analyzer_review_builder.py` that verify accepted/reject filtering, accepted-close joins, behavior without `close_outcomes`, failure when `events_context` is missing, and deterministic summary content.

### Testing
- Ran the new focused test suite and related Phase 2 tests with `PYTHONPATH=. pytest -q tests/offline/test_delta_analyzer_review_builder.py tests/offline/test_delta_analyzer_phase2.py deltascout/test/test_delta_analyzer_phase2_contracts.py` and all tests passed.
- The test run completed with `13 passed` and verified the new builder behavior, join semantics, missing-input failure, and generated markdown summary.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd1490a7688323b85ce479abb7c715)