### PR TITLE
Add post-close watcher script with runbook and unit tests

### DIFF
--- a/docs/runbooks/post_close_watcher.md
+++ b/docs/runbooks/post_close_watcher.md
@@ -1,0 +1,35 @@
+# Post-close watcher
+
+`scripts/offline/run_post_close_watcher.py` is a small cron-friendly orchestrator for DeltaScout post-close research automation.
+
+## Canonical trigger source
+
+The watcher uses only `/root/volume-alert/data/state/trade_outcomes.jsonl` as its close-event trigger source.
+It does not use `executor.log`, `executor_state.json`, generated close outcome CSVs, or review outputs as triggers.
+
+## Behavior
+
+- Reads the latest valid close/outcome row from `trade_outcomes.jsonl`.
+- Skips malformed JSONL rows safely.
+- If `trade_outcomes.jsonl` is missing, empty, or has no new valid close row, the watcher exits cleanly without running the pipeline.
+- Processes only one latest close marker at a time, using `trade_key` when present and a timestamp/reason/side fallback when it is not.
+- Runs, in order, `build_phase1_derived`, `build_close_outcomes`, and `delta_analyzer --build-review` for the discovered UTC close date.
+- Updates `/root/volume-alert/data/state/post_close_watcher_state.json` only after all three steps succeed.
+
+## Intended usage
+
+Run it once per day from cron, for example early in the morning UTC after close outcomes for the prior session are expected to exist.
+Repeated daily runs are safe because the watcher exits quickly when the latest close marker is already processed.
+
+Recommended manual run pattern:
+
+```bash
+cd /root/volume-alert
+PYTHONPATH=/root/volume-alert /opt/aitrader/.venv/bin/python scripts/offline/run_post_close_watcher.py
+```
+
+Recommended cron pattern with log redirection under the current project layout:
+
+```cron
+10 6 * * * cd /root/volume-alert && PYTHONPATH=/root/volume-alert /opt/aitrader/.venv/bin/python scripts/offline/run_post_close_watcher.py >> /root/volume-alert/data/logs/post_close_watcher.log 2>&1
+```

--- a/scripts/offline/run_post_close_watcher.py
+++ b/scripts/offline/run_post_close_watcher.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from datetime import datetime, timezone
+
+
+def _parse_utc_timestamp(raw: Any) -> datetime:
+    if raw is None:
+        raise ValueError("missing timestamp")
+    text = str(raw).strip()
+    if not text:
+        raise ValueError("missing timestamp")
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError as exc:
+        raise ValueError(f"invalid timestamp: {raw}") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+
+def _iter_jsonl_rows(path: Path):
+    with path.open("r", encoding="utf-8") as handle:
+        for line_no, raw_line in enumerate(handle, start=1):
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                yield line_no, json.loads(line)
+            except Exception as exc:
+                print(f"watcher skip malformed row path={path} line={line_no} error={exc}", file=sys.stderr)
+
+
+def _extract_close_record(row: Any) -> dict[str, Any] | None:
+    if not isinstance(row, dict):
+        return None
+    last_closed = row.get("last_closed")
+    if not isinstance(last_closed, dict) or not last_closed:
+        return None
+    close_ts = last_closed.get("ts") or last_closed.get("closed_at") or row.get("ts")
+    try:
+        _parse_utc_timestamp(close_ts)
+    except ValueError:
+        return None
+    return {
+        "schema": row.get("schema"),
+        "event": row.get("event"),
+        "record_ts": row.get("ts"),
+        "symbol": row.get("symbol"),
+        "source": row.get("source"),
+        "close": last_closed,
+    }
+
+
+def _load_latest_valid_close(trade_outcomes_file: Path) -> dict[str, Any] | None:
+    if not trade_outcomes_file.exists():
+        print(f"watcher no-op missing trigger file: {trade_outcomes_file}")
+        return None
+
+    latest: dict[str, Any] | None = None
+    latest_ts = None
+    for _, row in _iter_jsonl_rows(trade_outcomes_file):
+        close_record = _extract_close_record(row)
+        if not close_record:
+            continue
+        try:
+            candidate_ts = _parse_utc_timestamp(
+                close_record["close"].get("ts") or close_record["close"].get("closed_at") or close_record.get("record_ts")
+            )
+        except ValueError:
+            continue
+        if latest is None or candidate_ts >= latest_ts:
+            latest = close_record
+            latest_ts = candidate_ts
+
+    if latest is None:
+        print(f"watcher no-op no valid close rows found in {trade_outcomes_file}")
+    return latest
+
+
+def _normalized_marker_fields(close_row: dict[str, Any]) -> tuple[str, str, str]:
+    close = close_row["close"]
+    ts = _parse_utc_timestamp(close.get("ts") or close.get("closed_at") or close_row.get("record_ts"))
+    reason = str(close.get("reason") or close.get("close_reason") or "").strip().upper()
+    side = str(close.get("side") or "").strip().upper()
+    return ts.isoformat(), reason, side
+
+
+def _processed_marker(close_row: dict[str, Any]) -> str:
+    close = close_row["close"]
+    trade_key = str(close.get("trade_key") or "").strip()
+    if trade_key:
+        return f"trade_key:{trade_key}"
+    ts, reason, side = _normalized_marker_fields(close_row)
+    return f"fallback:{ts}|{reason}|{side}"
+
+
+def _target_date(close_row: dict[str, Any]) -> str:
+    ts, _, _ = _normalized_marker_fields(close_row)
+    return ts[:10]
+
+
+def _load_state(state_file: Path) -> dict[str, Any]:
+    if not state_file.exists():
+        return {}
+    return json.loads(state_file.read_text(encoding="utf-8"))
+
+
+def _write_state(state_file: Path, marker: str, close_row: dict[str, Any], target_date: str) -> None:
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    close = close_row["close"]
+    state = {
+        "last_processed_marker": marker,
+        "last_processed_trade_key": close.get("trade_key"),
+        "last_processed_close_ts": close.get("ts") or close.get("closed_at") or close_row.get("record_ts"),
+        "last_processed_reason": close.get("reason") or close.get("close_reason"),
+        "last_processed_side": close.get("side"),
+        "last_processed_date": target_date,
+        "last_processed_record_ts": close_row.get("record_ts"),
+    }
+    state_file.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"watcher state update success file={state_file} marker={marker}")
+
+
+def _run_step(name: str, cmd: list[str], project_root: Path, pythonpath: str) -> None:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = pythonpath
+    print(f"watcher step start name={name} cmd={' '.join(cmd)}")
+    subprocess.run(cmd, check=True, cwd=project_root, env=env)
+    print(f"watcher step success name={name}")
+
+
+def run(args: argparse.Namespace) -> int:
+    trade_outcomes_file = Path(args.trade_outcomes_file)
+    state_file = Path(args.state_file)
+    project_root = Path(args.project_root)
+    input_root = Path(args.input_root)
+    output_root = Path(args.output_root)
+
+    print(f"watcher start trigger={trade_outcomes_file} state={state_file}")
+    latest_close = _load_latest_valid_close(trade_outcomes_file)
+    if latest_close is None:
+        return 0
+
+    marker = _processed_marker(latest_close)
+    target_date = _target_date(latest_close)
+    close = latest_close["close"]
+    print(
+        "watcher latest close "
+        f"trade_key={close.get('trade_key')} timestamp={close.get('ts') or close.get('closed_at') or latest_close.get('record_ts')} date={target_date} marker={marker}"
+    )
+
+    state = _load_state(state_file)
+    if state.get("last_processed_marker") == marker:
+        print(f"watcher no-op already processed marker={marker}")
+        return 0
+
+    python_bin = args.python_bin
+    steps = [
+        (
+            "build_phase1_derived",
+            [python_bin, "scripts/offline/build_phase1_derived.py", "--date", target_date, "--input-root", str(input_root), "--output-root", str(output_root)],
+        ),
+        (
+            "build_close_outcomes",
+            [
+                python_bin,
+                "scripts/offline/build_close_outcomes.py",
+                "--date",
+                target_date,
+                "--input-root",
+                str(input_root),
+                "--output-root",
+                str(output_root),
+                "--trade-outcomes-file",
+                str(trade_outcomes_file),
+            ],
+        ),
+        (
+            "delta_analyzer_review",
+            [
+                python_bin,
+                "-m",
+                "deltascout.delta_analyzer.cli",
+                "--build-review",
+                "--date",
+                target_date,
+                "--input-root",
+                str(output_root),
+                "--output-root",
+                str(output_root),
+            ],
+        ),
+    ]
+
+    try:
+        for name, cmd in steps:
+            _run_step(name, cmd, project_root=project_root, pythonpath=str(project_root))
+    except subprocess.CalledProcessError as exc:
+        print(f"watcher failure step={name} exit_code={exc.returncode}", file=sys.stderr)
+        return exc.returncode or 1
+
+    _write_state(state_file, marker, latest_close, target_date)
+    print(f"watcher success date={target_date} marker={marker}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run DeltaScout post-close research pipeline once for the latest new close event.")
+    parser.add_argument("--project-root", default="/root/volume-alert", help="Project root used as subprocess cwd and PYTHONPATH.")
+    parser.add_argument("--input-root", default="/root/volume-alert/data", help="Input root for offline builders.")
+    parser.add_argument("--output-root", default="/root/volume-alert/data/archive/datasets", help="Dataset output root for offline builders and review build.")
+    parser.add_argument("--trade-outcomes-file", default="/root/volume-alert/data/state/trade_outcomes.jsonl", help="Canonical append-only close/outcome journal.")
+    parser.add_argument("--state-file", default="/root/volume-alert/data/state/post_close_watcher_state.json", help="Watcher state file updated only after full success.")
+    parser.add_argument("--python-bin", default="/opt/aitrader/.venv/bin/python", help="Python interpreter used for subprocess pipeline steps.")
+    return parser
+
+
+if __name__ == "__main__":
+    raise SystemExit(run(build_parser().parse_args()))

--- a/tests/offline/test_post_close_watcher.py
+++ b/tests/offline/test_post_close_watcher.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from argparse import Namespace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.offline.run_post_close_watcher import (
+    _load_latest_valid_close,
+    _processed_marker,
+    run,
+)
+
+
+def _args(tmp_path: Path, trade_file: Path, state_file: Path) -> Namespace:
+    return Namespace(
+        project_root=str(tmp_path),
+        input_root=str(tmp_path / "data"),
+        output_root=str(tmp_path / "data" / "archive" / "datasets"),
+        trade_outcomes_file=str(trade_file),
+        state_file=str(state_file),
+        python_bin="/usr/bin/python3",
+    )
+
+
+def _write_lines(path: Path, lines: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+
+
+def _valid_row(*, ts: str = "2026-01-01T00:30:00Z", trade_key: str | None = "TK-1", reason: str = "TP1", side: str = "LONG") -> dict[str, Any]:
+    last_closed: dict[str, Any] = {"ts": ts, "reason": reason, "side": side, "mode": "paper", "close_price": 101.0}
+    if trade_key is not None:
+        last_closed["trade_key"] = trade_key
+    return {
+        "schema": 2,
+        "event": "EXEC_CLOSE",
+        "ts": ts,
+        "symbol": "BTCUSDC",
+        "source": "executor",
+        "last_closed": last_closed,
+    }
+
+
+def test_missing_trade_outcomes_file_noop(tmp_path):
+    trade_file = tmp_path / "missing.jsonl"
+    state_file = tmp_path / "state.json"
+
+    rc = run(_args(tmp_path, trade_file, state_file))
+
+    assert rc == 0
+    assert not state_file.exists()
+
+
+def test_empty_trade_outcomes_file_noop(tmp_path):
+    trade_file = tmp_path / "trade_outcomes.jsonl"
+    state_file = tmp_path / "state.json"
+    _write_lines(trade_file, [])
+
+    rc = run(_args(tmp_path, trade_file, state_file))
+
+    assert rc == 0
+    assert not state_file.exists()
+
+
+def test_malformed_rows_before_valid_row_still_processed(tmp_path, monkeypatch):
+    trade_file = tmp_path / "trade_outcomes.jsonl"
+    state_file = tmp_path / "state.json"
+    _write_lines(trade_file, ["not-json", json.dumps({"foo": "bar"}), json.dumps(_valid_row())])
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, check, cwd, env):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr("scripts.offline.run_post_close_watcher.subprocess.run", fake_run)
+
+    rc = run(_args(tmp_path, trade_file, state_file))
+
+    assert rc == 0
+    assert len(calls) == 3
+    state = json.loads(state_file.read_text(encoding="utf-8"))
+    assert state["last_processed_marker"] == "trade_key:TK-1"
+
+
+def test_latest_row_already_processed_noop_no_subprocess_calls(tmp_path, monkeypatch):
+    trade_file = tmp_path / "trade_outcomes.jsonl"
+    row = _valid_row(trade_key="TK-2")
+    _write_lines(trade_file, [json.dumps(row)])
+    state_file = tmp_path / "state.json"
+    state_file.write_text(json.dumps({"last_processed_marker": "trade_key:TK-2"}), encoding="utf-8")
+
+    def fail_run(*args, **kwargs):  # pragma: no cover
+        raise AssertionError("subprocess.run should not be called")
+
+    monkeypatch.setattr("scripts.offline.run_post_close_watcher.subprocess.run", fail_run)
+
+    rc = run(_args(tmp_path, trade_file, state_file))
+
+    assert rc == 0
+
+
+def test_new_valid_row_runs_pipeline_in_order(tmp_path, monkeypatch):
+    trade_file = tmp_path / "trade_outcomes.jsonl"
+    _write_lines(trade_file, [json.dumps(_valid_row(ts="2026-01-02T01:30:00Z", trade_key="TK-3"))])
+    state_file = tmp_path / "state.json"
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, check, cwd, env):
+        calls.append(cmd)
+        assert env["PYTHONPATH"] == str(tmp_path)
+        assert cwd == tmp_path
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr("scripts.offline.run_post_close_watcher.subprocess.run", fake_run)
+
+    rc = run(_args(tmp_path, trade_file, state_file))
+
+    assert rc == 0
+    assert calls == [
+        ["/usr/bin/python3", "scripts/offline/build_phase1_derived.py", "--date", "2026-01-02", "--input-root", str(tmp_path / "data"), "--output-root", str(tmp_path / "data" / "archive" / "datasets")],
+        ["/usr/bin/python3", "scripts/offline/build_close_outcomes.py", "--date", "2026-01-02", "--input-root", str(tmp_path / "data"), "--output-root", str(tmp_path / "data" / "archive" / "datasets"), "--trade-outcomes-file", str(trade_file)],
+        ["/usr/bin/python3", "-m", "deltascout.delta_analyzer.cli", "--build-review", "--date", "2026-01-02", "--input-root", str(tmp_path / "data" / "archive" / "datasets"), "--output-root", str(tmp_path / "data" / "archive" / "datasets")],
+    ]
+    state = json.loads(state_file.read_text(encoding="utf-8"))
+    assert state["last_processed_marker"] == "trade_key:TK-3"
+    assert state["last_processed_date"] == "2026-01-02"
+
+
+@pytest.mark.parametrize("failing_step", [0, 1, 2])
+def test_pipeline_failure_does_not_update_state(tmp_path, monkeypatch, failing_step):
+    trade_file = tmp_path / "trade_outcomes.jsonl"
+    _write_lines(trade_file, [json.dumps(_valid_row(trade_key="TK-4"))])
+    state_file = tmp_path / "state.json"
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, check, cwd, env):
+        idx = len(calls)
+        calls.append(cmd)
+        if idx == failing_step:
+            raise subprocess.CalledProcessError(returncode=7, cmd=cmd)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr("scripts.offline.run_post_close_watcher.subprocess.run", fake_run)
+
+    rc = run(_args(tmp_path, trade_file, state_file))
+
+    assert rc == 7
+    assert len(calls) == failing_step + 1
+    assert not state_file.exists()
+
+
+def test_trade_key_based_processed_marker_works(tmp_path):
+    trade_file = tmp_path / "trade_outcomes.jsonl"
+    _write_lines(trade_file, [json.dumps(_valid_row(trade_key="TK-555"))])
+
+    latest = _load_latest_valid_close(trade_file)
+
+    assert latest is not None
+    assert _processed_marker(latest) == "trade_key:TK-555"
+
+
+def test_fallback_processed_marker_works_without_trade_key(tmp_path):
+    trade_file = tmp_path / "trade_outcomes.jsonl"
+    _write_lines(trade_file, [json.dumps(_valid_row(trade_key=None, ts="2026-01-03T05:45:00Z", reason="sl", side="short"))])
+
+    latest = _load_latest_valid_close(trade_file)
+
+    assert latest is not None
+    assert _processed_marker(latest) == "fallback:2026-01-03T05:45:00+00:00|SL|SHORT"


### PR DESCRIPTION
### Motivation
- Provide a cron-friendly orchestrator to automatically run DeltaScout post-close research once per new close/outcome event recorded in the canonical `trade_outcomes.jsonl` trigger file.
- Ensure the pipeline is idempotent and safe for repeated daily runs by tracking processed markers in a state file and skipping already-processed closes.

### Description
- Add `scripts/offline/run_post_close_watcher.py` which reads `/root/volume-alert/data/state/trade_outcomes.jsonl`, skips malformed JSONL rows, selects the latest valid close row, and computes a processed marker using `trade_key` with a timestamp/reason/side fallback.
- The watcher runs three ordered steps for the discovered UTC close date: `build_phase1_derived`, `build_close_outcomes`, and `delta_analyzer --build-review`, and only updates `post_close_watcher_state.json` after all steps succeed.
- Provide CLI arguments and sane defaults for `--project-root`, `--input-root`, `--output-root`, `--trade-outcomes-file`, `--state-file`, and `--python-bin`, and export `PYTHONPATH` for subprocess steps.
- Add a runbook `docs/runbooks/post_close_watcher.md` with canonical trigger, behavior, and recommended manual/cron usage examples.
- Add comprehensive pytest unit tests in `tests/offline/test_post_close_watcher.py` that cover missing/empty files, malformed rows, marker generation, pipeline order, failure behavior, and state updates while mocking `subprocess.run`.

### Testing
- Ran the new unit test module with `pytest tests/offline/test_post_close_watcher.py` where tests mock subprocess calls to avoid external side effects; all tests passed locally.
- The tests exercised `run`, `_load_latest_valid_close`, and `_processed_marker` behavior and verified state file creation and non-creation on failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd439ad1c083239b861782b7458671)