### PR TITLE
Add reject reason summary to Phase 2.5 review builds

### DIFF
--- a/deltascout/delta_analyzer/README.md
+++ b/deltascout/delta_analyzer/README.md
@@ -75,4 +75,4 @@ python -m deltascout.delta_analyzer.cli --build-review --date YYYY-MM-DD --input
 
 The default globs already point to the local research-material folder copied for DeltaScout research.
 
-The review-builder mode is the Phase 2.5 skeleton only: it reads daily `events_context` plus optional `close_outcomes`, then writes accepted/reject review tables and a deterministic Markdown summary under `reviews/YYYY-MM-DD/`.
+The review-builder mode is the Phase 2.5 skeleton only: it reads daily `events_context` plus optional `close_outcomes`, then writes accepted/reject review tables, `reject_reason_summary_YYYY-MM-DD.csv`, and a deterministic Markdown summary under `reviews/YYYY-MM-DD/`.

--- a/deltascout/delta_analyzer/modules/build_review_tables.py
+++ b/deltascout/delta_analyzer/modules/build_review_tables.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import csv
 from dataclasses import dataclass
-from importlib import import_module
 from datetime import datetime, timezone
+from importlib import import_module
 from pathlib import Path
+from statistics import mean, median
 from typing import Any
 
 ACCEPTED_EVENT_TYPE = "PEAK_EMIT"
@@ -46,6 +47,36 @@ ACCEPTED_JOIN_FIELDS = (
     "entry",
     "side",
 )
+REJECT_REASON_SUMMARY_FIELDS = (
+    "date",
+    "reject_reason",
+    "kind",
+    "count",
+    "cum_delta_60m_mean",
+    "cum_delta_60m_median",
+    "cum_delta_180m_mean",
+    "cum_delta_180m_median",
+    "ret_15m_mean",
+    "ret_15m_median",
+    "ret_60m_mean",
+    "ret_60m_median",
+    "dist_vwap_mean",
+    "dist_vwap_median",
+    "abs_dist_vwap_mean",
+    "abs_dist_vwap_median",
+    "price_vs_vwap_side_mode",
+    "price_vs_vwap_side_mode_count",
+)
+REJECT_REASON_NUMERIC_FIELDS = (
+    "cum_delta_60m",
+    "cum_delta_180m",
+    "ret_15m",
+    "ret_60m",
+    "dist_vwap",
+    "abs_dist_vwap",
+)
+UNKNOWN_REJECT_REASON = "UNKNOWN"
+UNKNOWN_KIND = "UNKNOWN"
 
 
 class ReviewBuildError(RuntimeError):
@@ -61,18 +92,25 @@ class ReviewBuildResult:
     output_dir: Path
     accepted_path: Path
     reject_path: Path
+    reject_reason_summary_path: Path
     summary_path: Path
 
 
-def build_daily_review_package(date: str, input_root: Path | str, output_root: Path | str) -> ReviewBuildResult:
+def build_daily_review_package(
+    date: str, input_root: Path | str, output_root: Path | str
+) -> ReviewBuildResult:
     input_root = Path(input_root)
     output_root = Path(output_root)
 
-    events_context_rows = _load_required_csv(input_root / f"events_context_{date}.csv", required_name="events_context")
+    events_context_rows = _load_required_csv(
+        input_root / f"events_context_{date}.csv", required_name="events_context"
+    )
     close_outcome_rows = _load_optional_close_outcomes(input_root, date)
     close_outcomes_by_key = _index_close_outcomes(close_outcome_rows)
 
-    accepted_rows = build_accepted_event_context_rows(events_context_rows, close_outcomes_by_key)
+    accepted_rows = build_accepted_event_context_rows(
+        events_context_rows, close_outcomes_by_key
+    )
     reject_rows = build_reject_event_context_rows(events_context_rows)
 
     review_dir = output_root / "reviews" / date
@@ -80,11 +118,34 @@ def build_daily_review_package(date: str, input_root: Path | str, output_root: P
 
     accepted_path = review_dir / f"accepted_event_context_{date}.csv"
     reject_path = review_dir / f"reject_event_context_{date}.csv"
+    reject_reason_summary_path = review_dir / f"reject_reason_summary_{date}.csv"
     summary_path = review_dir / f"daily_review_summary_{date}.md"
+    reject_reason_summary_rows = build_reject_reason_summary_rows(date, reject_rows)
 
-    _write_csv(accepted_path, accepted_rows, BASE_FIELDS + CONTEXT_FIELDS + ACCEPTED_JOIN_FIELDS)
+    _write_csv(
+        accepted_path,
+        accepted_rows,
+        BASE_FIELDS + CONTEXT_FIELDS + ACCEPTED_JOIN_FIELDS,
+    )
     _write_csv(reject_path, reject_rows, _ordered_reject_fields(reject_rows))
-    summary_path.write_text(_build_summary(date, accepted_rows, reject_rows, accepted_path, reject_path, summary_path), encoding="utf-8")
+    _write_csv(
+        reject_reason_summary_path,
+        reject_reason_summary_rows,
+        REJECT_REASON_SUMMARY_FIELDS,
+    )
+    summary_path.write_text(
+        _build_summary(
+            date,
+            accepted_rows,
+            reject_rows,
+            reject_reason_summary_rows,
+            accepted_path,
+            reject_path,
+            reject_reason_summary_path,
+            summary_path,
+        ),
+        encoding="utf-8",
+    )
 
     return ReviewBuildResult(
         date=date,
@@ -94,6 +155,7 @@ def build_daily_review_package(date: str, input_root: Path | str, output_root: P
         output_dir=review_dir,
         accepted_path=accepted_path,
         reject_path=reject_path,
+        reject_reason_summary_path=reject_reason_summary_path,
         summary_path=summary_path,
     )
 
@@ -106,20 +168,60 @@ def build_accepted_event_context_rows(
     for row in events_context_rows:
         if row.get("event_type") != ACCEPTED_EVENT_TYPE:
             continue
-        output_row = {field: row.get(field, "") for field in BASE_FIELDS + CONTEXT_FIELDS}
-        close_row = close_outcomes_by_key.get((_normalize_ts_key(row.get("ts")), _normalize_kind_key(row.get("kind"))))
+        output_row = {
+            field: row.get(field, "") for field in BASE_FIELDS + CONTEXT_FIELDS
+        }
+        close_row = close_outcomes_by_key.get(
+            (_normalize_ts_key(row.get("ts")), _normalize_kind_key(row.get("kind")))
+        )
         for field in ACCEPTED_JOIN_FIELDS:
             output_row[field] = close_row.get(field, "") if close_row else ""
         rows.append(output_row)
     return rows
 
 
-def build_reject_event_context_rows(events_context_rows: list[dict[str, str]]) -> list[dict[str, str]]:
+def build_reject_event_context_rows(
+    events_context_rows: list[dict[str, str]],
+) -> list[dict[str, str]]:
     rows: list[dict[str, str]] = []
     for row in events_context_rows:
         if row.get("event_type") in REJECT_EVENT_TYPES:
             rows.append(dict(row))
     return rows
+
+
+def build_reject_reason_summary_rows(
+    date: str,
+    reject_rows: list[dict[str, str]],
+) -> list[dict[str, str]]:
+    grouped: dict[tuple[str, str], list[dict[str, str]]] = {}
+    for row in reject_rows:
+        reject_reason = (
+            row.get("reject_reason") or ""
+        ).strip() or UNKNOWN_REJECT_REASON
+        kind = (row.get("kind") or "").strip() or UNKNOWN_KIND
+        grouped.setdefault((reject_reason, kind), []).append(row)
+
+    summary_rows: list[dict[str, str]] = []
+    for reject_reason, kind in sorted(grouped):
+        rows = grouped[(reject_reason, kind)]
+        summary_row = {
+            "date": date,
+            "reject_reason": reject_reason,
+            "kind": kind,
+            "count": str(len(rows)),
+        }
+        for field in REJECT_REASON_NUMERIC_FIELDS:
+            values = _collect_numeric_values(rows, field)
+            summary_row[f"{field}_mean"] = _format_stat(values, mean)
+            summary_row[f"{field}_median"] = _format_stat(values, median)
+        mode_value, mode_count = _mode_with_count(rows, "price_vs_vwap_side")
+        summary_row["price_vs_vwap_side_mode"] = mode_value
+        summary_row["price_vs_vwap_side_mode_count"] = (
+            str(mode_count) if mode_count else ""
+        )
+        summary_rows.append(summary_row)
+    return summary_rows
 
 
 def _ordered_reject_fields(rows: list[dict[str, str]]) -> tuple[str, ...]:
@@ -164,18 +266,30 @@ def _load_parquet(path: Path) -> list[dict[str, str]]:
     try:
         pd = import_module("pandas")
     except ModuleNotFoundError as exc:
-        raise ReviewBuildError(f"parquet close_outcomes requires pandas: {path}") from exc
+        raise ReviewBuildError(
+            f"parquet close_outcomes requires pandas: {path}"
+        ) from exc
     rows = pd.read_parquet(path).fillna("").to_dict(orient="records")
-    return [{str(key): "" if value is None else str(value) for key, value in row.items()} for row in rows]
+    return [
+        {str(key): "" if value is None else str(value) for key, value in row.items()}
+        for row in rows
+    ]
 
 
-def _index_close_outcomes(rows: list[dict[str, str]]) -> dict[tuple[str, str], dict[str, str]]:
+def _index_close_outcomes(
+    rows: list[dict[str, str]],
+) -> dict[tuple[str, str], dict[str, str]]:
     indexed: dict[tuple[str, str], dict[str, str]] = {}
     for row in rows:
-        key = (_normalize_ts_key(row.get("peak_ts")), _normalize_kind_key(row.get("peak_kind")))
+        key = (
+            _normalize_ts_key(row.get("peak_ts")),
+            _normalize_kind_key(row.get("peak_kind")),
+        )
         if not key[0]:
             continue
-        indexed.setdefault(key, {field: row.get(field, "") for field in ACCEPTED_JOIN_FIELDS})
+        indexed.setdefault(
+            key, {field: row.get(field, "") for field in ACCEPTED_JOIN_FIELDS}
+        )
     return indexed
 
 
@@ -201,7 +315,49 @@ def _normalize_kind_key(value: Any) -> str:
     return str(value or "").strip().lower()
 
 
-def _write_csv(path: Path, rows: list[dict[str, str]], fieldnames: tuple[str, ...]) -> None:
+def _collect_numeric_values(rows: list[dict[str, str]], field: str) -> list[float]:
+    values: list[float] = []
+    for row in rows:
+        parsed = _parse_float(row.get(field, ""))
+        if parsed is not None:
+            values.append(parsed)
+    return values
+
+
+def _parse_float(value: Any) -> float | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def _format_stat(values: list[float], aggregator: Any) -> str:
+    if not values:
+        return ""
+    return format(aggregator(values), "g")
+
+
+def _mode_with_count(rows: list[dict[str, str]], field: str) -> tuple[str, int]:
+    counts: dict[str, int] = {}
+    for row in rows:
+        value = (row.get(field) or "").strip()
+        if not value:
+            continue
+        counts[value] = counts.get(value, 0) + 1
+    if not counts:
+        return "", 0
+    mode_value, mode_count = sorted(
+        counts.items(), key=lambda item: (-item[1], item[0])
+    )[0]
+    return mode_value, mode_count
+
+
+def _write_csv(
+    path: Path, rows: list[dict[str, str]], fieldnames: tuple[str, ...]
+) -> None:
     with path.open("w", encoding="utf-8", newline="") as handle:
         writer = csv.DictWriter(handle, fieldnames=fieldnames, extrasaction="ignore")
         writer.writeheader()
@@ -213,15 +369,19 @@ def _build_summary(
     date: str,
     accepted_rows: list[dict[str, str]],
     reject_rows: list[dict[str, str]],
+    reject_reason_summary_rows: list[dict[str, str]],
     accepted_path: Path,
     reject_path: Path,
+    reject_reason_summary_path: Path,
     summary_path: Path,
 ) -> str:
     matched_close_count = sum(1 for row in accepted_rows if row.get("join_status"))
     reason_counts: dict[str, int] = {}
-    for row in reject_rows:
-        reason = (row.get("reject_reason") or "").strip() or "<missing>"
-        reason_counts[reason] = reason_counts.get(reason, 0) + 1
+    for row in reject_reason_summary_rows:
+        reason = row.get("reject_reason", "")
+        reason_counts[reason] = reason_counts.get(reason, 0) + int(
+            row.get("count") or 0
+        )
 
     lines = [
         f"# Daily Review Summary {date}",
@@ -230,6 +390,8 @@ def _build_summary(
         f"- accepted_row_count: {len(accepted_rows)}",
         f"- reject_row_count: {len(reject_rows)}",
         f"- accepted_with_close_outcomes: {matched_close_count}",
+        f"- reject_reason_summary_created: {reject_reason_summary_path.name}",
+        f"- reject_reason_summary_group_count: {len(reject_reason_summary_rows)}",
         "- reject_counts_by_reason:",
     ]
     if reason_counts:
@@ -242,6 +404,7 @@ def _build_summary(
             "- files_created:",
             f"  - {accepted_path.name}",
             f"  - {reject_path.name}",
+            f"  - {reject_reason_summary_path.name}",
             f"  - {summary_path.name}",
             "",
         ]

--- a/tests/offline/test_delta_analyzer_review_builder.py
+++ b/tests/offline/test_delta_analyzer_review_builder.py
@@ -10,7 +10,9 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from deltascout.delta_analyzer.modules.build_review_tables import build_daily_review_package
+from deltascout.delta_analyzer.modules.build_review_tables import (
+    build_daily_review_package,
+)
 
 
 EVENTS_CONTEXT_FIELDS = [
@@ -63,6 +65,7 @@ def _write_parquet(path: Path, rows: list[dict[str, str]]) -> None:
     pd = pytest.importorskip("pandas")
     path.parent.mkdir(parents=True, exist_ok=True)
     pd.DataFrame(rows).to_parquet(path, index=False)
+
 
 @pytest.fixture
 def dataset_root(tmp_path: Path) -> Path:
@@ -171,7 +174,9 @@ def dataset_root(tmp_path: Path) -> Path:
     return tmp_path
 
 
-def test_accepted_table_includes_peak_emit_rows_only(dataset_root: Path, tmp_path: Path):
+def test_accepted_table_includes_peak_emit_rows_only(
+    dataset_root: Path, tmp_path: Path
+):
     result = build_daily_review_package("2026-01-02", dataset_root, tmp_path)
 
     with result.accepted_path.open("r", encoding="utf-8", newline="") as handle:
@@ -181,7 +186,6 @@ def test_accepted_table_includes_peak_emit_rows_only(dataset_root: Path, tmp_pat
     assert {row["event_type"] for row in rows} == {"PEAK_EMIT"}
 
 
-
 def test_reject_table_includes_only_reject_rows(dataset_root: Path, tmp_path: Path):
     result = build_daily_review_package("2026-01-02", dataset_root, tmp_path)
 
@@ -189,11 +193,15 @@ def test_reject_table_includes_only_reject_rows(dataset_root: Path, tmp_path: Pa
         rows = list(csv.DictReader(handle))
 
     assert len(rows) == 2
-    assert {row["event_type"] for row in rows} == {"CANDIDATE_GATE_REJECT", "CANDIDATE_COMPARISON_REJECT"}
+    assert {row["event_type"] for row in rows} == {
+        "CANDIDATE_GATE_REJECT",
+        "CANDIDATE_COMPARISON_REJECT",
+    }
 
 
-
-def test_accepted_table_joins_close_outcomes_on_peak_ts_and_peak_kind(dataset_root: Path, tmp_path: Path):
+def test_accepted_table_joins_close_outcomes_on_peak_ts_and_peak_kind(
+    dataset_root: Path, tmp_path: Path
+):
     _write_csv(
         dataset_root / "close_outcomes_2026-01-02.csv",
         CLOSE_OUTCOME_FIELDS,
@@ -223,9 +231,9 @@ def test_accepted_table_joins_close_outcomes_on_peak_ts_and_peak_kind(dataset_ro
     assert result.matched_close_count == 1
 
 
-
-
-def test_accepted_table_joins_close_outcomes_from_parquet_when_csv_absent(dataset_root: Path, tmp_path: Path):
+def test_accepted_table_joins_close_outcomes_from_parquet_when_csv_absent(
+    dataset_root: Path, tmp_path: Path
+):
     _write_parquet(
         dataset_root / "close_outcomes_2026-01-02.parquet",
         [
@@ -251,7 +259,9 @@ def test_accepted_table_joins_close_outcomes_from_parquet_when_csv_absent(datase
     assert result.matched_close_count == 1
 
 
-def test_accepted_table_joins_close_outcomes_when_event_ts_is_naive_and_outcome_ts_is_utc_aware(dataset_root: Path, tmp_path: Path):
+def test_accepted_table_joins_close_outcomes_when_event_ts_is_naive_and_outcome_ts_is_utc_aware(
+    dataset_root: Path, tmp_path: Path
+):
     _write_csv(
         dataset_root / "events_context_2026-01-02.csv",
         EVENTS_CONTEXT_FIELDS,
@@ -291,7 +301,9 @@ def test_accepted_table_joins_close_outcomes_when_event_ts_is_naive_and_outcome_
     assert result.matched_close_count == 1
 
 
-def test_build_succeeds_without_close_outcomes_and_leaves_join_fields_empty(dataset_root: Path, tmp_path: Path):
+def test_build_succeeds_without_close_outcomes_and_leaves_join_fields_empty(
+    dataset_root: Path, tmp_path: Path
+):
     result = build_daily_review_package("2026-01-02", dataset_root, tmp_path)
 
     with result.accepted_path.open("r", encoding="utf-8", newline="") as handle:
@@ -303,14 +315,17 @@ def test_build_succeeds_without_close_outcomes_and_leaves_join_fields_empty(data
     assert result.matched_close_count == 0
 
 
-
 def test_build_fails_clearly_when_events_context_is_missing(tmp_path: Path):
-    with pytest.raises(RuntimeError, match=r"missing events_context input: .+events_context_2026-01-02\.csv"):
+    with pytest.raises(
+        RuntimeError,
+        match=r"missing events_context input: .+events_context_2026-01-02\.csv",
+    ):
         build_daily_review_package("2026-01-02", tmp_path, tmp_path)
 
 
-
-def test_markdown_summary_is_created_with_required_counts(dataset_root: Path, tmp_path: Path):
+def test_markdown_summary_is_created_with_required_counts(
+    dataset_root: Path, tmp_path: Path
+):
     _write_csv(
         dataset_root / "close_outcomes_2026-01-02.csv",
         CLOSE_OUTCOME_FIELDS,
@@ -335,8 +350,180 @@ def test_markdown_summary_is_created_with_required_counts(dataset_root: Path, tm
     assert "accepted_row_count: 1" in summary
     assert "reject_row_count: 2" in summary
     assert "accepted_with_close_outcomes: 1" in summary
+    assert (
+        "reject_reason_summary_created: reject_reason_summary_2026-01-02.csv" in summary
+    )
+    assert "reject_reason_summary_group_count: 2" in summary
     assert "comparison_fail: 1" in summary
     assert "weak_delta: 1" in summary
     assert result.accepted_path.name in summary
     assert result.reject_path.name in summary
+    assert result.reject_reason_summary_path.name in summary
     assert result.summary_path.name in summary
+
+
+def test_reject_reason_summary_groups_by_reject_reason_and_kind_with_stats(
+    dataset_root: Path, tmp_path: Path
+):
+    _write_csv(
+        dataset_root / "events_context_2026-01-02.csv",
+        EVENTS_CONTEXT_FIELDS,
+        [
+            {
+                **{field: "" for field in EVENTS_CONTEXT_FIELDS},
+                "ts": "2026-01-02T00:20:00Z",
+                "day": "2026-01-02",
+                "event_type": "CANDIDATE_GATE_REJECT",
+                "kind": "short",
+                "reject_reason": "vwap_side",
+                "cum_delta_180m": "10",
+                "cum_delta_60m": "2",
+                "ret_15m": "-1",
+                "ret_60m": "-2",
+                "dist_vwap": "-1",
+                "abs_dist_vwap": "1",
+                "price_vs_vwap_side": "below",
+            },
+            {
+                **{field: "" for field in EVENTS_CONTEXT_FIELDS},
+                "ts": "2026-01-02T00:25:00Z",
+                "day": "2026-01-02",
+                "event_type": "CANDIDATE_GATE_REJECT",
+                "kind": "short",
+                "reject_reason": "vwap_side",
+                "cum_delta_180m": "14",
+                "cum_delta_60m": "6",
+                "ret_15m": "3",
+                "ret_60m": "4",
+                "dist_vwap": "-3",
+                "abs_dist_vwap": "3",
+                "price_vs_vwap_side": "below",
+            },
+            {
+                **{field: "" for field in EVENTS_CONTEXT_FIELDS},
+                "ts": "2026-01-02T00:30:00Z",
+                "day": "2026-01-02",
+                "event_type": "CANDIDATE_COMPARISON_REJECT",
+                "kind": "long",
+                "reject_reason": "direction_mismatch",
+                "cum_delta_180m": "11",
+                "cum_delta_60m": "5",
+                "ret_15m": "1",
+                "ret_60m": "2",
+                "dist_vwap": "2",
+                "abs_dist_vwap": "2",
+                "price_vs_vwap_side": "above",
+            },
+        ],
+    )
+
+    result = build_daily_review_package("2026-01-02", dataset_root, tmp_path)
+    with result.reject_reason_summary_path.open(
+        "r", encoding="utf-8", newline=""
+    ) as handle:
+        rows = list(csv.DictReader(handle))
+
+    assert [(row["reject_reason"], row["kind"], row["count"]) for row in rows] == [
+        ("direction_mismatch", "long", "1"),
+        ("vwap_side", "short", "2"),
+    ]
+    vwap_side_row = rows[1]
+    assert vwap_side_row["cum_delta_60m_mean"] == "4"
+    assert vwap_side_row["cum_delta_60m_median"] == "4"
+    assert vwap_side_row["cum_delta_180m_mean"] == "12"
+    assert vwap_side_row["cum_delta_180m_median"] == "12"
+    assert vwap_side_row["ret_15m_mean"] == "1"
+    assert vwap_side_row["ret_15m_median"] == "1"
+    assert vwap_side_row["ret_60m_mean"] == "1"
+    assert vwap_side_row["ret_60m_median"] == "1"
+    assert vwap_side_row["dist_vwap_mean"] == "-2"
+    assert vwap_side_row["dist_vwap_median"] == "-2"
+    assert vwap_side_row["abs_dist_vwap_mean"] == "2"
+    assert vwap_side_row["abs_dist_vwap_median"] == "2"
+    assert vwap_side_row["price_vs_vwap_side_mode"] == "below"
+    assert vwap_side_row["price_vs_vwap_side_mode_count"] == "2"
+
+
+def test_reject_reason_summary_is_empty_with_header_when_no_reject_rows(tmp_path: Path):
+    _write_csv(
+        tmp_path / "events_context_2026-01-02.csv",
+        EVENTS_CONTEXT_FIELDS,
+        [
+            {
+                **{field: "" for field in EVENTS_CONTEXT_FIELDS},
+                "ts": "2026-01-02T00:10:00Z",
+                "day": "2026-01-02",
+                "event_type": "PEAK_EMIT",
+                "kind": "long",
+            }
+        ],
+    )
+
+    result = build_daily_review_package("2026-01-02", tmp_path, tmp_path)
+
+    with result.reject_reason_summary_path.open(
+        "r", encoding="utf-8", newline=""
+    ) as handle:
+        rows = list(csv.DictReader(handle))
+
+    assert rows == []
+    summary = result.summary_path.read_text(encoding="utf-8")
+    assert "reject_row_count: 0" in summary
+    assert "reject_reason_summary_group_count: 0" in summary
+    assert "<none>: 0" in summary
+
+
+def test_reject_reason_summary_skips_missing_numeric_values_without_crashing(
+    dataset_root: Path, tmp_path: Path
+):
+    _write_csv(
+        dataset_root / "events_context_2026-01-02.csv",
+        EVENTS_CONTEXT_FIELDS,
+        [
+            {
+                **{field: "" for field in EVENTS_CONTEXT_FIELDS},
+                "ts": "2026-01-02T00:20:00Z",
+                "day": "2026-01-02",
+                "event_type": "CANDIDATE_GATE_REJECT",
+                "kind": "",
+                "reject_reason": "",
+                "cum_delta_180m": "",
+                "cum_delta_60m": "bad-number",
+                "ret_15m": "",
+                "ret_60m": "5",
+                "dist_vwap": "",
+                "abs_dist_vwap": "7",
+            },
+            {
+                **{field: "" for field in EVENTS_CONTEXT_FIELDS},
+                "ts": "2026-01-02T00:30:00Z",
+                "day": "2026-01-02",
+                "event_type": "CANDIDATE_COMPARISON_REJECT",
+                "kind": "",
+                "reject_reason": "",
+                "cum_delta_180m": "",
+                "cum_delta_60m": "",
+                "ret_15m": "",
+                "ret_60m": "",
+                "dist_vwap": "",
+                "abs_dist_vwap": "",
+            },
+        ],
+    )
+
+    result = build_daily_review_package("2026-01-02", dataset_root, tmp_path)
+    with result.reject_reason_summary_path.open(
+        "r", encoding="utf-8", newline=""
+    ) as handle:
+        row = next(csv.DictReader(handle))
+
+    assert row["reject_reason"] == "UNKNOWN"
+    assert row["kind"] == "UNKNOWN"
+    assert row["count"] == "2"
+    assert row["cum_delta_60m_mean"] == ""
+    assert row["cum_delta_60m_median"] == ""
+    assert row["cum_delta_180m_mean"] == ""
+    assert row["ret_15m_mean"] == ""
+    assert row["ret_60m_mean"] == "5"
+    assert row["ret_60m_median"] == "5"
+    assert row["abs_dist_vwap_mean"] == "7"


### PR DESCRIPTION
### Motivation
- Provide a minimal, deterministic Phase 2.5 research output that aggregates reject rows into reason-level structure so downstream research can consume reason-level counts and basic context statistics.
- Keep the change narrow and auditable by deriving the summary from the already-built `reject_event_context` rows and preserving existing accepted/reject output contracts.

### Description
- Add generation of `reject_reason_summary_YYYY-MM-DD.csv` written to `<output_root>/reviews/YYYY-MM-DD/` and include it in the Phase 2.5 build order after `reject_event_context` and before the markdown summary.
- Implement grouping by `(reject_reason, kind)` with deterministic fallbacks `UNKNOWN` when those fields are missing, and compute `count` plus mean/median statistics for existing Phase 2 context numeric fields (`cum_delta_60m`, `cum_delta_180m`, `ret_15m`, `ret_60m`, `dist_vwap`, `abs_dist_vwap`) and optional `price_vs_vwap_side` mode and its count.
- Handle missing/invalid numeric values deterministically by skipping them and emitting empty cells when a group has no valid values for a metric.
- Integrate the new summary artifact into the `daily_review_summary_YYYY-MM-DD.md` so the markdown mechanically reports the summary filename, group count, and grouped reject counts (derived from the summary CSV).
- Files changed: `deltascout/delta_analyzer/modules/build_review_tables.py`, `tests/offline/test_delta_analyzer_review_builder.py`, and a small README note in `deltascout/delta_analyzer/README.md`.

### Testing
- Ran formatting: `python -m black deltascout/delta_analyzer/modules/build_review_tables.py tests/offline/test_delta_analyzer_review_builder.py` succeeded and reformatted files as expected.
- Ran unit tests: `pytest tests/offline/test_delta_analyzer_review_builder.py` — result: 10 passed, 1 skipped (the parquet test gated by optional `pandas`), all new tests passed.
- New targeted tests cover grouping by `(reject_reason, kind)`, counts, mean/median stats, empty-reject handling (header-only output), missing/invalid numeric values resilience, and markdown integration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd6057785c832392e7117e2eccdf09)