### PR TITLE
docs: sync DeltaScout analyzer documentation

### DIFF
--- a/deltascout/README.md
+++ b/deltascout/README.md
@@ -130,13 +130,19 @@ Typical outputs:
 - `baseline_init_YYYY-MM-DD.parquet|csv`
 - `window_owner_miss_YYYY-MM-DD.parquet|csv`
 - `late_peak_YYYY-MM-DD.parquet|csv`
+- `events_context_YYYY-MM-DD.csv`
+- `reviews/YYYY-MM-DD/accepted_event_context_YYYY-MM-DD.csv`
+- `reviews/YYYY-MM-DD/reject_event_context_YYYY-MM-DD.csv`
+- `reviews/YYYY-MM-DD/reject_reason_summary_YYYY-MM-DD.csv`
+- `reviews/YYYY-MM-DD/daily_review_summary_YYYY-MM-DD.md`
 
 Builders:
 
-| Dataset area | Source | Script |
-|--------------|--------|--------|
-| Rejects, baseline init, ownership misses, late peaks | DeltaScout archive + feed archive | `scripts/offline/build_phase1_derived.py` |
-| Close outcomes | Primary: `trade_outcomes.jsonl`; fallback: executor artifacts | `scripts/offline/build_close_outcomes.py` |
+| Dataset area | Source | Builder |
+|--------------|--------|---------|
+| Rejects, baseline init, ownership misses, late peaks | DeltaScout archive + feed archive | `scripts.offline.build_phase1_derived` |
+| Close outcomes | Primary: `trade_outcomes.jsonl`; fallback: executor artifacts | `scripts.offline.build_close_outcomes` |
+| Event context + daily review artifacts | DeltaScout archive + feed archive; optional close outcomes join for accepted review rows | `deltascout.delta_analyzer` |
 
 ---
 
@@ -231,11 +237,12 @@ No manual action is required during collection.
 
 ### 2. Rebuild datasets after a trade close
 
-Run the offline builders for the UTC close date:
+In routine operation this is handled by the post-close watcher / cron flow. For a manual rebuild of the UTC close date, run:
 
 ```bash
-python scripts/offline/build_phase1_derived.py --date YYYY-MM-DD --input-root /data --output-root /data/archive/datasets
-python scripts/offline/build_close_outcomes.py --date YYYY-MM-DD --input-root /data --output-root /data/archive/datasets
+PYTHONPATH=/root/volume-alert /opt/aitrader/.venv/bin/python -m scripts.offline.build_phase1_derived --date YYYY-MM-DD --input-root /data --output-root /data/archive/datasets
+PYTHONPATH=/root/volume-alert /opt/aitrader/.venv/bin/python -m scripts.offline.build_close_outcomes --date YYYY-MM-DD --input-root /data --output-root /data/archive/datasets
+python -m deltascout.delta_analyzer.cli --build-review --date YYYY-MM-DD --input-root /data/archive/datasets --output-root /data/archive/datasets
 ```
 
 Expected outputs:
@@ -245,6 +252,11 @@ Expected outputs:
 - `window_owner_miss_YYYY-MM-DD.*`
 - `late_peak_YYYY-MM-DD.*`
 - `close_outcomes_YYYY-MM-DD.*`
+- `events_context_YYYY-MM-DD.csv`
+- `reviews/YYYY-MM-DD/accepted_event_context_YYYY-MM-DD.csv`
+- `reviews/YYYY-MM-DD/reject_event_context_YYYY-MM-DD.csv`
+- `reviews/YYYY-MM-DD/reject_reason_summary_YYYY-MM-DD.csv`
+- `reviews/YYYY-MM-DD/daily_review_summary_YYYY-MM-DD.md`
 
 ### 3. Validate outputs
 
@@ -261,43 +273,31 @@ If `join_status = missing`, it means the corresponding `PEAK_EMIT` was not found
 
 ## Research Roadmap
 
-### Phase 1: Data accumulation
+### Phase 1: Foundation / base derived layer
 
 Goal:
 
 - accumulate feed archive
 - accumulate DeltaScout decision archive
-- build baseline derived datasets
+- build the base derived datasets used for reject and close-outcome research
 
-### Phase 2: Signal research
+### Phase 2: Backward-looking event context
 
-Typical directions:
+Current focus:
 
-- signal density maps
-- profitability by delta bucket
-- profitability by regime
-- reject signal analysis
-- threshold sensitivity
+- build `events_context` as the per-event context layer
+- reconstruct cumulative delta and return context around archive events
+- preserve a deterministic research surface for later review and outcome joins
 
-Future dataset registry:
+### Phase 2.5: Daily review package
 
-```text
-/data/archive/datasets/manifest.json
-```
+Current focus:
 
-This should track dataset metadata such as name, file, build time, source date range, row count, and builder script.
+- build accepted and reject review tables from `events_context`
+- summarize reject reasons for the day
+- produce a deterministic daily review summary for repeated research use
 
-### Phase 3: Strategy modeling
-
-Potential directions:
-
-- adaptive thresholds
-- regime-specific signals
-- multi-factor signal scoring
-
-### Phase 4: Production strategy
-
-After statistical validation, new signal logic may be promoted into the live trading system.
+Later phases remain research-facing and should be defined from accumulated evidence rather than assumed in advance.
 
 ---
 
@@ -305,11 +305,11 @@ After statistical validation, new signal logic may be promoted into the live tra
 
 ```bash
 pip install pandas numpy
-python -u delta_scout.py
+python -u deltascout/delta_scout.py
 ```
 
 ## Tests
 
 ```bash
-pytest deltascout/test/ -v
+pytest tests/ deltascout/test/ -v
 ```

--- a/deltascout/delta_analyzer/delta_analyzer_implementation_plan_v1_1.md
+++ b/deltascout/delta_analyzer/delta_analyzer_implementation_plan_v1_1.md
@@ -461,6 +461,11 @@ Success criteria:
 
 Phase 2.5 introduces a deterministic research-review build layer on top of the already validated Phase 2 `events_context` dataset.
 
+Status note:
+- Phase 2.5 is implemented.
+- Current implemented outputs are `accepted_event_context_YYYY-MM-DD.csv`, `reject_event_context_YYYY-MM-DD.csv`, `reject_reason_summary_YYYY-MM-DD.csv`, and `daily_review_summary_YYYY-MM-DD.md`.
+- `interesting_rejects_YYYY-MM-DD.csv` and `event_sequence_review_YYYY-MM-DD.csv` remain future review-layer extensions beyond the current implemented baseline.
+
 Its purpose is **not** to expand signal logic or redesign PEAK.
 Its purpose is to convert archived daily materials into a research-operable review package that helps accumulate evidence for:
 
@@ -539,14 +544,17 @@ Recommended output directory:
 
 - `data/archive/datasets/reviews/YYYY-MM-DD/`
 
-Required outputs:
+Current implemented outputs:
 
 - `accepted_event_context_YYYY-MM-DD.csv`
 - `reject_event_context_YYYY-MM-DD.csv`
-- `interesting_rejects_YYYY-MM-DD.csv`
 - `reject_reason_summary_YYYY-MM-DD.csv`
-- `event_sequence_review_YYYY-MM-DD.csv`
 - `daily_review_summary_YYYY-MM-DD.md`
+
+Future review-layer extensions:
+
+- `interesting_rejects_YYYY-MM-DD.csv`
+- `event_sequence_review_YYYY-MM-DD.csv`
 
 CSV tables are the **primary outputs**.
 The Markdown file is a **derived human-readable summary** and must be generated from the tables rather than written manually.
@@ -963,17 +971,21 @@ Success criteria:
 ### Current status
 - Phase 1: closed
 - Phase 2: closed and validated
-- Immediate next step: Phase 2.5 review loop
+- Phase 2.5: implemented
+- accepted-event linkage: implemented
+- reject-event linkage: implemented
+- reject reason summary: implemented
+- daily review summary: implemented
 
 ### Next
 Should focus on:
-- accepted-event to close-outcome research linkage
-- interesting reject triage
-- reject reason / context sanity review
+- `interesting_rejects` as the next review-layer extension
 - repeated daily review outputs built on top of validated `events_context`
+- continued accepted/reject review against accumulated evidence
 
-### After Phase 2.5 evidence accumulates
+### After current review outputs accumulate more evidence
 Should focus on:
+- evidence-based review of whether sequence features are justified next
 - evidence-based Phase 3 planning
 - evidence-based state-layer review
 - evidence-based outcome-layer expansion


### PR DESCRIPTION
### Motivation

- Keep documentation aligned with the current implemented analyzer outputs and workflows by reflecting Phase 2 and Phase 2.5 artifacts and invocation patterns. 
- Replace stale direct-script command examples with the module-style invocation actually used in the post-close watcher, and make the manual rebuild flow accurate and conservative. 
- Make the roadmap factual about current implementation state (Phase 1/2/2.5) and avoid presenting unimplemented review outputs as done. 

### Description

- Updated `deltascout/README.md` to include `events_context_YYYY-MM-DD.csv` and review-package outputs under `reviews/YYYY-MM-DD/` in the Derived Datasets section, added `deltascout.delta_analyzer` as a builder, and adjusted the builders table accordingly. 
- Replaced old direct-script invocations with the module-style pattern and watcher-aware wording, adding examples using `PYTHONPATH=/root/volume-alert /opt/aitrader/.venv/bin/python -m ...` and the review-builder invocation `python -m deltascout.delta_analyzer.cli --build-review ...`. 
- Adjusted the Research Roadmap headings and phrasing in `deltascout/README.md` to `Phase 1: Foundation`, `Phase 2: Backward-looking event context`, and `Phase 2.5: Daily review package` and clarified the current focus for each. 
- Modified `deltascout/delta_analyzer/delta_analyzer_implementation_plan_v1_1.md` to add a concise Phase 2.5 status note stating `Phase 2.5 is implemented`, list the currently implemented Phase 2.5 outputs (`accepted_event_context_YYYY-MM-DD.csv`, `reject_event_context_YYYY-MM-DD.csv`, `reject_reason_summary_YYYY-MM-DD.csv`, `daily_review_summary_YYYY-MM-DD.md`), and mark `interesting_rejects` and `event_sequence_review` as future extensions; also updated the priority roadmap to reflect implemented linkage and summaries. 
- Minor run/tests sync: updated `Run` command to `python -u deltascout/delta_scout.py` and `Tests` to `pytest tests/ deltascout/test/ -v` for current layout. 

### Testing

- Verified the local diff for the two modified files with `git diff -- deltascout/README.md deltascout/delta_analyzer/delta_analyzer_implementation_plan_v1_1.md`. (succeeded)
- Committed the docs-only change with `git add` + `git commit -m "docs: sync deltascout analyzer docs"`. (succeeded)
- No unit tests or runtime tests were executed because this is a documentation-only patch per scope constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd85ed46c08323b41ee1ac5c6cb279)