### PR TITLE
Add deterministic interesting_rejects review builder (Phase 2.5)

### DIFF
--- a/deltascout/delta_analyzer/README.md
+++ b/deltascout/delta_analyzer/README.md
@@ -75,4 +75,4 @@ python -m deltascout.delta_analyzer.cli --build-review --date YYYY-MM-DD --input
 
 The default globs already point to the local research-material folder copied for DeltaScout research.
 
-The review-builder mode is the Phase 2.5 skeleton only: it reads daily `events_context` plus optional `close_outcomes`, then writes accepted/reject review tables, `reject_reason_summary_YYYY-MM-DD.csv`, and a deterministic Markdown summary under `reviews/YYYY-MM-DD/`.
+The review-builder mode is the Phase 2.5 review layer: it reads daily `events_context` plus optional `close_outcomes`, then writes accepted/reject review tables, `interesting_rejects_YYYY-MM-DD.csv`, `reject_reason_summary_YYYY-MM-DD.csv`, and a deterministic Markdown summary under `reviews/YYYY-MM-DD/`.

--- a/deltascout/delta_analyzer/delta_analyzer_implementation_plan_v1_1.md
+++ b/deltascout/delta_analyzer/delta_analyzer_implementation_plan_v1_1.md
@@ -463,8 +463,8 @@ Phase 2.5 introduces a deterministic research-review build layer on top of the a
 
 Status note:
 - Phase 2.5 is implemented.
-- Current implemented outputs are `accepted_event_context_YYYY-MM-DD.csv`, `reject_event_context_YYYY-MM-DD.csv`, `reject_reason_summary_YYYY-MM-DD.csv`, and `daily_review_summary_YYYY-MM-DD.md`.
-- `interesting_rejects_YYYY-MM-DD.csv` and `event_sequence_review_YYYY-MM-DD.csv` remain future review-layer extensions beyond the current implemented baseline.
+- Current implemented outputs are `accepted_event_context_YYYY-MM-DD.csv`, `reject_event_context_YYYY-MM-DD.csv`, `interesting_rejects_YYYY-MM-DD.csv`, `reject_reason_summary_YYYY-MM-DD.csv`, and `daily_review_summary_YYYY-MM-DD.md`.
+- `event_sequence_review_YYYY-MM-DD.csv` remains a future review-layer extension beyond the current implemented baseline.
 
 Its purpose is **not** to expand signal logic or redesign PEAK.
 Its purpose is to convert archived daily materials into a research-operable review package that helps accumulate evidence for:

--- a/deltascout/delta_analyzer/modules/build_review_tables.py
+++ b/deltascout/delta_analyzer/modules/build_review_tables.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from importlib import import_module
 from pathlib import Path
+from math import isnan
 from statistics import mean, median
 from typing import Any
 
@@ -79,6 +80,27 @@ UNKNOWN_REJECT_REASON = "UNKNOWN"
 UNKNOWN_KIND = "UNKNOWN"
 
 
+INTERESTING_REJECT_FIELDS = (
+    "interesting_reject_flag",
+    "interesting_reject_bucket",
+    "interesting_reject_note",
+    "interesting_rule_id",
+)
+INTERESTING_REJECT_EXCLUDED_REASONS = {"no_prev_peak", "imb_band"}
+INTERESTING_REJECT_REASON_SET = {"direction_mismatch", "vwap_side", "3of3_fail"}
+INTERESTING_REJECT_RULE_NOTES = {
+    "IR_B1": "supportive 60m/180m flow and 15m return context despite reject",
+    "IR_A1": "direction_mismatch with supportive 60m flow but weak/contrary 15m return",
+    "IR_A2": "vwap_side reject near VWAP with directional cumulative buildup",
+    "IR_D1": "strong cumulative flow with contrary price reaction; possible exhaustion probe",
+    "IR_E1": "local directional pressure but broader context does not confirm",
+    "IR_E2": "short-term continuation pressure against contrary medium-horizon context",
+    "IR_C1": "supportive flow and return context despite vwap-side rejection",
+    "IR_C2": "3of3 fail despite supportive medium-horizon pressure",
+    "IR_F1": "contextually non-trivial reject retained for review",
+}
+
+
 class ReviewBuildError(RuntimeError):
     """Raised when deterministic review-builder inputs are missing or invalid."""
 
@@ -88,10 +110,12 @@ class ReviewBuildResult:
     date: str
     accepted_count: int
     reject_count: int
+    interesting_reject_count: int
     matched_close_count: int
     output_dir: Path
     accepted_path: Path
     reject_path: Path
+    interesting_rejects_path: Path
     reject_reason_summary_path: Path
     summary_path: Path
 
@@ -112,12 +136,14 @@ def build_daily_review_package(
         events_context_rows, close_outcomes_by_key
     )
     reject_rows = build_reject_event_context_rows(events_context_rows)
+    interesting_reject_rows = build_interesting_reject_rows(reject_rows)
 
     review_dir = output_root / "reviews" / date
     review_dir.mkdir(parents=True, exist_ok=True)
 
     accepted_path = review_dir / f"accepted_event_context_{date}.csv"
     reject_path = review_dir / f"reject_event_context_{date}.csv"
+    interesting_rejects_path = review_dir / f"interesting_rejects_{date}.csv"
     reject_reason_summary_path = review_dir / f"reject_reason_summary_{date}.csv"
     summary_path = review_dir / f"daily_review_summary_{date}.md"
     reject_reason_summary_rows = build_reject_reason_summary_rows(date, reject_rows)
@@ -127,7 +153,13 @@ def build_daily_review_package(
         accepted_rows,
         BASE_FIELDS + CONTEXT_FIELDS + ACCEPTED_JOIN_FIELDS,
     )
-    _write_csv(reject_path, reject_rows, _ordered_reject_fields(reject_rows))
+    reject_fields = _ordered_reject_fields(reject_rows)
+    _write_csv(reject_path, reject_rows, reject_fields)
+    _write_csv(
+        interesting_rejects_path,
+        interesting_reject_rows,
+        _ordered_interesting_reject_fields(reject_fields, interesting_reject_rows),
+    )
     _write_csv(
         reject_reason_summary_path,
         reject_reason_summary_rows,
@@ -138,9 +170,11 @@ def build_daily_review_package(
             date,
             accepted_rows,
             reject_rows,
+            interesting_reject_rows,
             reject_reason_summary_rows,
             accepted_path,
             reject_path,
+            interesting_rejects_path,
             reject_reason_summary_path,
             summary_path,
         ),
@@ -151,10 +185,12 @@ def build_daily_review_package(
         date=date,
         accepted_count=len(accepted_rows),
         reject_count=len(reject_rows),
+        interesting_reject_count=len(interesting_reject_rows),
         matched_close_count=sum(1 for row in accepted_rows if row.get("join_status")),
         output_dir=review_dir,
         accepted_path=accepted_path,
         reject_path=reject_path,
+        interesting_rejects_path=interesting_rejects_path,
         reject_reason_summary_path=reject_reason_summary_path,
         summary_path=summary_path,
     )
@@ -190,6 +226,20 @@ def build_reject_event_context_rows(
     return rows
 
 
+def build_interesting_reject_rows(
+    reject_rows: list[dict[str, str]],
+) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    for row in reject_rows:
+        classification = _classify_interesting_reject(row)
+        if classification is None:
+            continue
+        output_row = dict(row)
+        output_row.update(classification)
+        rows.append(output_row)
+    return rows
+
+
 def build_reject_reason_summary_rows(
     date: str,
     reject_rows: list[dict[str, str]],
@@ -222,6 +272,260 @@ def build_reject_reason_summary_rows(
         )
         summary_rows.append(summary_row)
     return summary_rows
+
+
+def _classify_interesting_reject(row: dict[str, str]) -> dict[str, str] | None:
+    reject_reason = (row.get("reject_reason") or "").strip()
+    if reject_reason in INTERESTING_REJECT_EXCLUDED_REASONS:
+        return None
+
+    cum_delta_60m = _parse_float(row.get("cum_delta_60m", ""))
+    ret_15m = _parse_float(row.get("ret_15m", ""))
+    abs_dist_vwap = _parse_float(row.get("abs_dist_vwap", ""))
+    if (
+        cum_delta_60m is not None
+        and ret_15m is not None
+        and abs_dist_vwap is not None
+        and abs(cum_delta_60m) < 150
+        and abs(ret_15m) < 0.0015
+        and abs(abs_dist_vwap) < 150
+    ):
+        return None
+
+    rules = (
+        _match_ir_b1,
+        _match_ir_a1,
+        _match_ir_a2,
+        _match_ir_d1,
+        _match_ir_e1,
+        _match_ir_e2,
+        _match_ir_c1,
+        _match_ir_c2,
+        _match_ir_f1,
+    )
+    for rule in rules:
+        match = rule(row)
+        if match is not None:
+            return {
+                "interesting_reject_flag": "1",
+                "interesting_reject_bucket": match["bucket"],
+                "interesting_reject_note": INTERESTING_REJECT_RULE_NOTES[match["rule_id"]],
+                "interesting_rule_id": match["rule_id"],
+            }
+    return None
+
+
+def _ordered_interesting_reject_fields(
+    reject_fields: tuple[str, ...], rows: list[dict[str, str]]
+) -> tuple[str, ...]:
+    fields = list(reject_fields)
+    for field in INTERESTING_REJECT_FIELDS:
+        if field not in fields:
+            fields.append(field)
+    for row in rows:
+        for key in row:
+            if key not in fields:
+                fields.append(key)
+    return tuple(fields)
+
+
+def _match_ir_b1(row: dict[str, str]) -> dict[str, str] | None:
+    if (row.get("reject_reason") or "").strip() not in {"vwap_side", "3of3_fail"}:
+        return None
+    kind = _normalize_kind_key(row.get("kind"))
+    if not kind:
+        return None
+    if not (
+        _supports_kind(kind, row.get("cum_delta_60m"))
+        and _supports_kind(kind, row.get("cum_delta_180m"))
+        and _supports_kind(kind, row.get("ret_15m"))
+        and _abs_at_most(row.get("abs_dist_vwap"), 500)
+    ):
+        return None
+    return {"bucket": "possible_reversal_confirmation", "rule_id": "IR_B1"}
+
+
+def _match_ir_a1(row: dict[str, str]) -> dict[str, str] | None:
+    if (row.get("reject_reason") or "").strip() != "direction_mismatch":
+        return None
+    kind = _normalize_kind_key(row.get("kind"))
+    if not kind:
+        return None
+    if not _supports_kind(kind, row.get("cum_delta_60m")):
+        return None
+    if not (
+        _supports_kind(kind, row.get("cum_delta_180m"))
+        or _abs_below(row.get("cum_delta_180m"), 200)
+    ):
+        return None
+    if not (
+        _does_not_support_kind(kind, row.get("ret_15m"))
+        or _abs_below(row.get("ret_15m"), 0.001)
+    ):
+        return None
+    if not _abs_at_most(row.get("abs_dist_vwap"), 600):
+        return None
+    return {"bucket": "possible_reversal_onset", "rule_id": "IR_A1"}
+
+
+def _match_ir_a2(row: dict[str, str]) -> dict[str, str] | None:
+    if (row.get("reject_reason") or "").strip() != "vwap_side":
+        return None
+    kind = _normalize_kind_key(row.get("kind"))
+    if not kind:
+        return None
+    if not (
+        _supports_kind(kind, row.get("cum_delta_60m"))
+        and _opposes_kind(kind, row.get("ret_15m"))
+        and _abs_at_most(row.get("abs_dist_vwap"), 350)
+    ):
+        return None
+    return {"bucket": "possible_reversal_onset", "rule_id": "IR_A2"}
+
+
+def _match_ir_d1(row: dict[str, str]) -> dict[str, str] | None:
+    if (row.get("reject_reason") or "").strip() != "direction_mismatch":
+        return None
+    kind = _normalize_kind_key(row.get("kind"))
+    if not kind:
+        return None
+    if not _supports_kind_with_threshold(kind, row.get("cum_delta_60m"), 400):
+        return None
+    if not _opposes_kind(kind, row.get("ret_15m")):
+        return None
+    if not (_opposes_kind(kind, row.get("ret_60m")) or _abs_below(row.get("ret_60m"), 0.001)):
+        return None
+    if not _abs_at_least(row.get("abs_dist_vwap"), 200):
+        return None
+    return {"bucket": "possible_exhaustion_probe", "rule_id": "IR_D1"}
+
+
+def _match_ir_e1(row: dict[str, str]) -> dict[str, str] | None:
+    if (row.get("reject_reason") or "").strip() != "vwap_side":
+        return None
+    kind = _normalize_kind_key(row.get("kind"))
+    if not kind:
+        return None
+    if not _supports_kind(kind, row.get("cum_delta_60m")):
+        return None
+    if not (_opposes_kind(kind, row.get("ret_60m")) or _opposes_kind(kind, row.get("cum_delta_180m"))):
+        return None
+    if not _abs_at_least(row.get("abs_dist_vwap"), 200):
+        return None
+    return {"bucket": "possible_trap_or_false_break", "rule_id": "IR_E1"}
+
+
+def _match_ir_e2(row: dict[str, str]) -> dict[str, str] | None:
+    if (row.get("reject_reason") or "").strip() != "3of3_fail":
+        return None
+    kind = _normalize_kind_key(row.get("kind"))
+    if not kind:
+        return None
+    if not (
+        _supports_kind(kind, row.get("ret_15m"))
+        and _opposes_kind(kind, row.get("ret_60m"))
+        and _does_not_support_kind(kind, row.get("cum_delta_180m"))
+    ):
+        return None
+    return {"bucket": "possible_trap_or_false_break", "rule_id": "IR_E2"}
+
+
+def _match_ir_c1(row: dict[str, str]) -> dict[str, str] | None:
+    if (row.get("reject_reason") or "").strip() != "vwap_side":
+        return None
+    kind = _normalize_kind_key(row.get("kind"))
+    if not kind:
+        return None
+    if not (
+        _supports_kind(kind, row.get("cum_delta_60m"))
+        and _supports_kind(kind, row.get("ret_15m"))
+        and _supports_kind(kind, row.get("ret_60m"))
+        and _abs_at_most(row.get("abs_dist_vwap"), 800)
+    ):
+        return None
+    return {"bucket": "possible_continuation_pressure", "rule_id": "IR_C1"}
+
+
+def _match_ir_c2(row: dict[str, str]) -> dict[str, str] | None:
+    if (row.get("reject_reason") or "").strip() != "3of3_fail":
+        return None
+    kind = _normalize_kind_key(row.get("kind"))
+    if not kind:
+        return None
+    if not (
+        _supports_kind(kind, row.get("cum_delta_60m"))
+        and _supports_kind(kind, row.get("ret_60m"))
+        and _abs_at_most(row.get("abs_dist_vwap"), 700)
+    ):
+        return None
+    return {"bucket": "possible_continuation_pressure", "rule_id": "IR_C2"}
+
+
+def _match_ir_f1(row: dict[str, str]) -> dict[str, str] | None:
+    if (row.get("reject_reason") or "").strip() not in INTERESTING_REJECT_REASON_SET:
+        return None
+    conditions = sum(
+        (
+            _abs_at_least(row.get("cum_delta_60m"), 250),
+            _abs_at_least(row.get("cum_delta_180m"), 400),
+            _abs_at_least(row.get("ret_15m"), 0.002),
+            _abs_at_least(row.get("abs_dist_vwap"), 250),
+        )
+    )
+    if conditions < 2:
+        return None
+    return {"bucket": "unclear_but_constructive", "rule_id": "IR_F1"}
+
+
+def _supports_kind(kind: str, value: Any) -> bool:
+    parsed = _parse_float(value)
+    if parsed is None:
+        return False
+    if kind == "long":
+        return parsed > 0
+    if kind == "short":
+        return parsed < 0
+    return False
+
+
+def _supports_kind_with_threshold(kind: str, value: Any, threshold: float) -> bool:
+    parsed = _parse_float(value)
+    if parsed is None or abs(parsed) < threshold:
+        return False
+    return _supports_kind(kind, parsed)
+
+
+def _opposes_kind(kind: str, value: Any) -> bool:
+    parsed = _parse_float(value)
+    if parsed is None:
+        return False
+    if kind == "long":
+        return parsed < 0
+    if kind == "short":
+        return parsed > 0
+    return False
+
+
+def _does_not_support_kind(kind: str, value: Any) -> bool:
+    parsed = _parse_float(value)
+    if parsed is None:
+        return False
+    return not _supports_kind(kind, parsed)
+
+
+def _abs_below(value: Any, threshold: float) -> bool:
+    parsed = _parse_float(value)
+    return parsed is not None and abs(parsed) < threshold
+
+
+def _abs_at_most(value: Any, threshold: float) -> bool:
+    parsed = _parse_float(value)
+    return parsed is not None and abs(parsed) <= threshold
+
+
+def _abs_at_least(value: Any, threshold: float) -> bool:
+    parsed = _parse_float(value)
+    return parsed is not None and abs(parsed) >= threshold
 
 
 def _ordered_reject_fields(rows: list[dict[str, str]]) -> tuple[str, ...]:
@@ -329,9 +633,12 @@ def _parse_float(value: Any) -> float | None:
     if not text:
         return None
     try:
-        return float(text)
+        parsed = float(text)
     except ValueError:
         return None
+    if isnan(parsed):
+        return None
+    return parsed
 
 
 def _format_stat(values: list[float], aggregator: Any) -> str:
@@ -369,9 +676,11 @@ def _build_summary(
     date: str,
     accepted_rows: list[dict[str, str]],
     reject_rows: list[dict[str, str]],
+    interesting_reject_rows: list[dict[str, str]],
     reject_reason_summary_rows: list[dict[str, str]],
     accepted_path: Path,
     reject_path: Path,
+    interesting_rejects_path: Path,
     reject_reason_summary_path: Path,
     summary_path: Path,
 ) -> str:
@@ -389,6 +698,7 @@ def _build_summary(
         f"- processed_date: {date}",
         f"- accepted_row_count: {len(accepted_rows)}",
         f"- reject_row_count: {len(reject_rows)}",
+        f"- interesting_reject_row_count: {len(interesting_reject_rows)}",
         f"- accepted_with_close_outcomes: {matched_close_count}",
         f"- reject_reason_summary_created: {reject_reason_summary_path.name}",
         f"- reject_reason_summary_group_count: {len(reject_reason_summary_rows)}",
@@ -404,6 +714,7 @@ def _build_summary(
             "- files_created:",
             f"  - {accepted_path.name}",
             f"  - {reject_path.name}",
+            f"  - {interesting_rejects_path.name}",
             f"  - {reject_reason_summary_path.name}",
             f"  - {summary_path.name}",
             "",

--- a/tests/offline/test_delta_analyzer_review_builder.py
+++ b/tests/offline/test_delta_analyzer_review_builder.py
@@ -63,8 +63,24 @@ def _write_csv(path: Path, fieldnames: list[str], rows: list[dict[str, str]]) ->
 
 def _write_parquet(path: Path, rows: list[dict[str, str]]) -> None:
     pd = pytest.importorskip("pandas")
+    pyarrow = pytest.importorskip("pyarrow")
     path.parent.mkdir(parents=True, exist_ok=True)
-    pd.DataFrame(rows).to_parquet(path, index=False)
+    pd.DataFrame(rows).to_parquet(path, index=False, engine="pyarrow")
+
+
+def _make_events_context_row(**overrides: str) -> dict[str, str]:
+    row = {field: "" for field in EVENTS_CONTEXT_FIELDS}
+    row.update(
+        {
+            "ts": "2026-01-02T00:00:00Z",
+            "day": "2026-01-02",
+            "event_type": "CANDIDATE_GATE_REJECT",
+            "kind": "long",
+            "reject_reason": "direction_mismatch",
+        }
+    )
+    row.update(overrides)
+    return row
 
 
 @pytest.fixture
@@ -527,3 +543,105 @@ def test_reject_reason_summary_skips_missing_numeric_values_without_crashing(
     assert row["ret_60m_mean"] == "5"
     assert row["ret_60m_median"] == "5"
     assert row["abs_dist_vwap_mean"] == "7"
+
+
+def test_interesting_rejects_excludes_filtered_reasons_and_weak_context(tmp_path: Path):
+    _write_csv(
+        tmp_path / "events_context_2026-01-02.csv",
+        EVENTS_CONTEXT_FIELDS,
+        [
+            _make_events_context_row(ts="2026-01-02T00:01:00Z", reject_reason="no_prev_peak", cum_delta_60m="500", ret_15m="0.003", abs_dist_vwap="200"),
+            _make_events_context_row(ts="2026-01-02T00:02:00Z", reject_reason="imb_band", cum_delta_60m="500", ret_15m="0.003", abs_dist_vwap="200"),
+            _make_events_context_row(ts="2026-01-02T00:03:00Z", reject_reason="direction_mismatch", cum_delta_60m="149", ret_15m="0.0014", abs_dist_vwap="149"),
+        ],
+    )
+
+    result = build_daily_review_package("2026-01-02", tmp_path, tmp_path)
+
+    with result.interesting_rejects_path.open("r", encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+
+    assert rows == []
+    assert result.interesting_reject_count == 0
+
+
+def test_interesting_rejects_builds_expected_bucket_rows(tmp_path: Path):
+    rows = [
+        _make_events_context_row(ts="2026-01-02T00:01:00Z", reject_reason="vwap_side", kind="long", cum_delta_60m="300", cum_delta_180m="500", ret_15m="0.003", ret_60m="-0.004", abs_dist_vwap="450"),
+        _make_events_context_row(ts="2026-01-02T00:02:00Z", reject_reason="direction_mismatch", kind="long", cum_delta_60m="250", cum_delta_180m="150", ret_15m="-0.0005", abs_dist_vwap="300"),
+        _make_events_context_row(ts="2026-01-02T00:03:00Z", reject_reason="direction_mismatch", kind="long", cum_delta_60m="450", cum_delta_180m="-250", ret_15m="-0.004", ret_60m="-0.0005", abs_dist_vwap="220"),
+        _make_events_context_row(ts="2026-01-02T00:04:00Z", reject_reason="3of3_fail", kind="long", cum_delta_60m="200", cum_delta_180m="-50", ret_15m="0.003", ret_60m="-0.004", abs_dist_vwap="500"),
+        _make_events_context_row(ts="2026-01-02T00:05:00Z", reject_reason="3of3_fail", kind="short", cum_delta_60m="-350", cum_delta_180m="100", ret_15m="0.001", ret_60m="-0.004", abs_dist_vwap="650"),
+        _make_events_context_row(ts="2026-01-02T00:06:00Z", reject_reason="vwap_side", kind="long", cum_delta_60m="260", cum_delta_180m="100", ret_15m="0.0025", ret_60m="", abs_dist_vwap="900"),
+    ]
+    _write_csv(tmp_path / "events_context_2026-01-02.csv", EVENTS_CONTEXT_FIELDS, rows)
+
+    result = build_daily_review_package("2026-01-02", tmp_path, tmp_path)
+
+    with result.interesting_rejects_path.open("r", encoding="utf-8", newline="") as handle:
+        interesting_rows = list(csv.DictReader(handle))
+
+    assert [(row["interesting_rule_id"], row["interesting_reject_bucket"]) for row in interesting_rows] == [
+        ("IR_B1", "possible_reversal_confirmation"),
+        ("IR_A1", "possible_reversal_onset"),
+        ("IR_D1", "possible_exhaustion_probe"),
+        ("IR_E2", "possible_trap_or_false_break"),
+        ("IR_C2", "possible_continuation_pressure"),
+        ("IR_F1", "unclear_but_constructive"),
+    ]
+    assert all(row["interesting_reject_flag"] == "1" for row in interesting_rows)
+
+
+def test_interesting_rejects_uses_first_match_wins_ordering(tmp_path: Path):
+    _write_csv(
+        tmp_path / "events_context_2026-01-02.csv",
+        EVENTS_CONTEXT_FIELDS,
+        [
+            _make_events_context_row(
+                ts="2026-01-02T00:01:00Z",
+                reject_reason="vwap_side",
+                kind="long",
+                cum_delta_60m="500",
+                cum_delta_180m="500",
+                ret_15m="0.004",
+                ret_60m="0.005",
+                abs_dist_vwap="300",
+            )
+        ],
+    )
+
+    result = build_daily_review_package("2026-01-02", tmp_path, tmp_path)
+
+    with result.interesting_rejects_path.open("r", encoding="utf-8", newline="") as handle:
+        row = next(csv.DictReader(handle))
+
+    assert row["interesting_rule_id"] == "IR_B1"
+    assert row["interesting_reject_bucket"] == "possible_reversal_confirmation"
+
+
+
+def test_interesting_rejects_writes_empty_schema_when_no_rows_match(tmp_path: Path):
+    _write_csv(
+        tmp_path / "events_context_2026-01-02.csv",
+        EVENTS_CONTEXT_FIELDS,
+        [
+            _make_events_context_row(ts="2026-01-02T00:01:00Z", reject_reason="no_prev_peak", cum_delta_60m="200", ret_15m="0.003", abs_dist_vwap="200")
+        ],
+    )
+
+    result = build_daily_review_package("2026-01-02", tmp_path, tmp_path)
+
+    with result.interesting_rejects_path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        rows = list(reader)
+
+    assert rows == []
+    assert reader.fieldnames == EVENTS_CONTEXT_FIELDS + [
+        "interesting_reject_flag",
+        "interesting_reject_bucket",
+        "interesting_reject_note",
+        "interesting_rule_id",
+    ]
+    summary = result.summary_path.read_text(encoding="utf-8")
+    assert "interesting_reject_row_count: 0" in summary
+    assert result.interesting_rejects_path.name in summary


### PR DESCRIPTION
### Motivation
- Add a Phase 2.5 deterministic review-layer builder that produces `reviews/YYYY-MM-DD/interesting_rejects_YYYY-MM-DD.csv` as a triage subset of `reject_event_context`, keeping the change small, auditable, and strictly within review-layer scope. 
- The builder must follow strict constraints: no sequence/state/look-ahead/ML logic, robust numeric handling, and deterministic first-match-wins triage rules.

### Description
- Integrate `interesting_rejects` into the existing review build flow by extending `build_daily_review_package` to call `build_interesting_reject_rows` and write `interesting_rejects_{date}.csv`, update the `ReviewBuildResult` to include `interesting_rejects_path` and `interesting_reject_count`, and surface the count in the markdown summary. Files changed: `deltascout/delta_analyzer/modules/build_review_tables.py`, tests `tests/offline/test_delta_analyzer_review_builder.py`, and minor doc edits in `deltascout/delta_analyzer/README.md` and `deltascout/delta_analyzer/delta_analyzer_implementation_plan_v1_1.md`.
- Implement deterministic classification helpers: `build_interesting_reject_rows`, `_classify_interesting_reject`, per-rule matchers `_match_ir_b1`, `_match_ir_a1`, `_match_ir_a2`, `_match_ir_d1`, `_match_ir_e1`, `_match_ir_e2`, `_match_ir_c1`, `_match_ir_c2`, `_match_ir_f1`, and directional helpers `_supports_kind`, `_opposes_kind`, `_does_not_support_kind`, plus numeric helpers `_abs_at_most/_abs_at_least/_abs_below` and robust `_parse_float` (treats missing/NaN as non-matching).
- Enforce pre-filter exclusions and weak-context exclusion: drop rows with `reject_reason` in `{

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0de0894688323ab986157f6a8dfe8)