### PR TITLE
Make enriched archived feed canonical; remove legacy fallback and expose matched feed fields in reviews

### DIFF
--- a/deltascout/delta_analyzer/Delta_Analyzer_Phase1_Spec.md
+++ b/deltascout/delta_analyzer/Delta_Analyzer_Phase1_Spec.md
@@ -67,6 +67,8 @@ Archive ingestion:
 
 Feed ingestion:
 
+- use `/opt/aitrader/feed/*.csv` as the canonical default feed source unless `--feed-glob` is provided explicitly
+- fail loudly when the selected feed glob matches no files
 - read CSV files with `Timestamp`
 - sort rows by timestamp
 - use `ClosePrice` as preferred price, fallback to `AvgPrice`

--- a/deltascout/delta_analyzer/README.md
+++ b/deltascout/delta_analyzer/README.md
@@ -16,7 +16,7 @@ It exists to build a clean base layer for future analyzer work around:
 Phase 1 implements only the foundation layer:
 
 - read archive JSONL files
-- read archived feed CSV files, preferring `/opt/aitrader/feed/*.csv` by default while preserving CLI override support
+- read archived feed CSV files from the canonical `/opt/aitrader/feed/*.csv` default while preserving explicit CLI override support
 - normalize rows into simple internal types, including additive support for optional `OpenInterest`, `FundingRate`, `LiqBuyQty`, and `LiqSellQty` columns when present
 - match event timestamps to nearest feed row with `feed_ts <= event_ts`
 - build `events_base`
@@ -73,6 +73,6 @@ python -m deltascout.delta_analyzer.cli --dataset events_context
 python -m deltascout.delta_analyzer.cli --build-review --date YYYY-MM-DD --input-root /data/archive/datasets --output-root /data/archive/datasets
 ```
 
-The default archive glob still points to the local research-material archive sample. The default feed glob now prefers `/opt/aitrader/feed/*.csv`; if that default path has no matches, the analyzer falls back to the legacy local research-material feed glob. Any explicit `--feed-glob` override still wins.
+The default archive glob still points to the local research-material archive sample. The default feed glob is now the canonical enriched archive path `/opt/aitrader/feed/*.csv`, and the analyzer fails loudly when that glob matches no files. Any explicit `--feed-glob` override still wins.
 
 The review-builder mode is the Phase 2.5 review layer: it reads daily `events_context` plus optional `close_outcomes`, then writes accepted/reject review tables, `interesting_rejects_YYYY-MM-DD.csv`, `reject_reason_summary_YYYY-MM-DD.csv`, and a deterministic Markdown summary under `reviews/YYYY-MM-DD/`.

--- a/deltascout/delta_analyzer/cli.py
+++ b/deltascout/delta_analyzer/cli.py
@@ -5,7 +5,7 @@ import glob
 from collections import Counter
 from pathlib import Path
 
-from .config import DEFAULT_ARCHIVE_GLOB, DEFAULT_FEED_GLOB, LEGACY_DEFAULT_FEED_GLOB
+from .config import DEFAULT_ARCHIVE_GLOB, DEFAULT_FEED_GLOB
 from .modules.archive_reader import read_archive_events
 from .modules.build_events_base import build_events_base_dataset
 from .modules.build_events_context import build_events_context_dataset
@@ -48,10 +48,7 @@ def _expand_glob(pattern: str) -> list[Path]:
 
 
 def _resolve_feed_files(pattern: str) -> list[Path]:
-    files = _expand_glob(pattern)
-    if files or pattern != DEFAULT_FEED_GLOB:
-        return files
-    return _expand_glob(LEGACY_DEFAULT_FEED_GLOB)
+    return _expand_glob(pattern)
 
 
 def main() -> None:
@@ -73,6 +70,8 @@ def main() -> None:
 
     archive_files = _expand_glob(args.archive_glob)
     feed_files = _resolve_feed_files(args.feed_glob)
+    if not feed_files:
+        raise SystemExit(f"no feed files matched: {args.feed_glob}")
 
     events = read_archive_events(archive_files)
     feed_rows = read_feed_rows(feed_files)

--- a/deltascout/delta_analyzer/config.py
+++ b/deltascout/delta_analyzer/config.py
@@ -8,6 +8,5 @@ DELTA_ROOT = MODULE_ROOT.parent
 DEFAULT_RESEARCH_ROOT = DELTA_ROOT / "research_material"
 DEFAULT_ARCHIVE_GLOB = str(DEFAULT_RESEARCH_ROOT / "raw_archive" / "*.jsonl")
 DEFAULT_FEED_GLOB = "/opt/aitrader/feed/*.csv"
-LEGACY_DEFAULT_FEED_GLOB = str(DEFAULT_RESEARCH_ROOT / "raw_feed" / "*.csv")
 
 RAW_DELTA_EVENTS = {"DELTA_MAX", "DELTA_MIN"}

--- a/deltascout/delta_analyzer/delta_analyzer_implementation_plan_v1_1.md
+++ b/deltascout/delta_analyzer/delta_analyzer_implementation_plan_v1_1.md
@@ -584,6 +584,11 @@ Expected fields include:
   - `dist_vwap`
   - `abs_dist_vwap`
   - `price_vs_vwap_side`
+- matched feed enrichment fields already attached to the event row:
+  - `matched_open_interest`
+  - `matched_funding_rate`
+  - `matched_liq_buy_qty`
+  - `matched_liq_sell_qty`
 - close-outcome join fields when available:
   - `join_status`
   - `join_confidence`
@@ -612,6 +617,7 @@ Expected fields include:
 - candidate kind
 - reject reason
 - current Phase 2 context block
+- matched feed enrichment fields already attached to the event row
 - selected raw archive fields already present on the row
 
 #### 3. interesting_rejects

--- a/deltascout/delta_analyzer/modules/build_review_tables.py
+++ b/deltascout/delta_analyzer/modules/build_review_tables.py
@@ -14,6 +14,12 @@ REJECT_EVENT_TYPES = (
     "CANDIDATE_COMPARISON_REJECT",
     "CANDIDATE_GATE_REJECT",
 )
+MATCHED_FEED_FIELDS = (
+    "matched_open_interest",
+    "matched_funding_rate",
+    "matched_liq_buy_qty",
+    "matched_liq_sell_qty",
+)
 BASE_FIELDS = (
     "ts",
     "day",
@@ -27,6 +33,8 @@ BASE_FIELDS = (
     "vwap",
     "poc",
     "matched_feed_ts",
+)
+REVIEW_SHARED_FIELDS = BASE_FIELDS + MATCHED_FEED_FIELDS + (
     "source_file",
     "terminal_decision_present",
 )
@@ -151,7 +159,7 @@ def build_daily_review_package(
     _write_csv(
         accepted_path,
         accepted_rows,
-        BASE_FIELDS + CONTEXT_FIELDS + ACCEPTED_JOIN_FIELDS,
+        REVIEW_SHARED_FIELDS + CONTEXT_FIELDS + ACCEPTED_JOIN_FIELDS,
     )
     reject_fields = _ordered_reject_fields(reject_rows)
     _write_csv(reject_path, reject_rows, reject_fields)
@@ -205,7 +213,7 @@ def build_accepted_event_context_rows(
         if row.get("event_type") != ACCEPTED_EVENT_TYPE:
             continue
         output_row = {
-            field: row.get(field, "") for field in BASE_FIELDS + CONTEXT_FIELDS
+            field: row.get(field, "") for field in REVIEW_SHARED_FIELDS + CONTEXT_FIELDS
         }
         close_row = close_outcomes_by_key.get(
             (_normalize_ts_key(row.get("ts")), _normalize_kind_key(row.get("kind")))
@@ -529,7 +537,7 @@ def _abs_at_least(value: Any, threshold: float) -> bool:
 
 
 def _ordered_reject_fields(rows: list[dict[str, str]]) -> tuple[str, ...]:
-    preferred = list(BASE_FIELDS + CONTEXT_FIELDS)
+    preferred = list(REVIEW_SHARED_FIELDS + CONTEXT_FIELDS)
     extras: list[str] = []
     for row in rows:
         for key in row:

--- a/deltascout/test/test_delta_analyzer_phase2_contracts.py
+++ b/deltascout/test/test_delta_analyzer_phase2_contracts.py
@@ -24,6 +24,10 @@ def _feed(ts: str, *, price: float | None, buy: float | None, sell: float | None
         price=price,
         buy_qty=buy,
         sell_qty=sell,
+        open_interest=None,
+        funding_rate=None,
+        liq_buy_qty=None,
+        liq_sell_qty=None,
         row={},
         source_file="synthetic_feed.csv",
     )
@@ -59,6 +63,10 @@ def _base_row(ts: str) -> EventsBaseRow:
         vwap=100.0,
         poc=99.0,
         matched_feed_ts=_dt("2026-01-02T00:15:00"),
+        matched_open_interest=None,
+        matched_funding_rate=None,
+        matched_liq_buy_qty=None,
+        matched_liq_sell_qty=None,
         source_file="synthetic_event.jsonl",
         terminal_decision_present=True,
     )

--- a/tests/offline/test_delta_analyzer_feed_reader.py
+++ b/tests/offline/test_delta_analyzer_feed_reader.py
@@ -106,26 +106,24 @@ def test_enriched_feed_fields_propagate_into_analyzer_output(tmp_path):
     assert context_rows[0].matched_liq_sell_qty == 8.0
 
 
-def test_resolve_feed_files_prefers_default_archive_source_and_falls_back(monkeypatch):
+def test_resolve_feed_files_uses_canonical_default_without_fallback(monkeypatch):
     monkeypatch.setattr(cli, "DEFAULT_FEED_GLOB", "/opt/aitrader/feed/*.csv")
-    monkeypatch.setattr(cli, "LEGACY_DEFAULT_FEED_GLOB", "legacy/*.csv")
+
+    calls: list[str] = []
 
     def fake_expand(pattern: str):
+        calls.append(pattern)
         if pattern == "/opt/aitrader/feed/*.csv":
-            return []
-        if pattern == "legacy/*.csv":
-            return ["legacy/day.csv"]
+            return ["/opt/aitrader/feed/2026-01-02.csv"]
         raise AssertionError(pattern)
 
     monkeypatch.setattr(cli, "_expand_glob", fake_expand)
 
-    assert cli._resolve_feed_files("/opt/aitrader/feed/*.csv") == ["legacy/day.csv"]
+    assert cli._resolve_feed_files("/opt/aitrader/feed/*.csv") == ["/opt/aitrader/feed/2026-01-02.csv"]
+    assert calls == ["/opt/aitrader/feed/*.csv"]
 
 
 def test_resolve_feed_files_preserves_explicit_override_without_fallback(monkeypatch):
-    monkeypatch.setattr(cli, "DEFAULT_FEED_GLOB", "/opt/aitrader/feed/*.csv")
-    monkeypatch.setattr(cli, "LEGACY_DEFAULT_FEED_GLOB", "legacy/*.csv")
-
     calls: list[str] = []
 
     def fake_expand(pattern: str):
@@ -136,3 +134,28 @@ def test_resolve_feed_files_preserves_explicit_override_without_fallback(monkeyp
 
     assert cli._resolve_feed_files("custom/*.csv") == []
     assert calls == ["custom/*.csv"]
+
+
+def test_main_fails_loudly_when_feed_glob_has_no_matches(monkeypatch):
+    monkeypatch.setattr(cli, "_expand_glob", lambda pattern: [])
+
+    class FakeParser:
+        def parse_args(self):
+            return cli.argparse.Namespace(
+                archive_glob=cli.DEFAULT_ARCHIVE_GLOB,
+                feed_glob=cli.DEFAULT_FEED_GLOB,
+                dataset="events_context",
+                build_review=False,
+                date=None,
+                input_root=cli.DEFAULT_DATASET_ROOT,
+                output_root=cli.DEFAULT_DATASET_ROOT,
+            )
+
+    monkeypatch.setattr(cli, "build_parser", lambda: FakeParser())
+
+    try:
+        cli.main()
+    except SystemExit as exc:
+        assert str(exc) == "no feed files matched: /opt/aitrader/feed/*.csv"
+    else:
+        raise AssertionError("expected SystemExit")

--- a/tests/offline/test_delta_analyzer_review_builder.py
+++ b/tests/offline/test_delta_analyzer_review_builder.py
@@ -28,6 +28,10 @@ EVENTS_CONTEXT_FIELDS = [
     "vwap",
     "poc",
     "matched_feed_ts",
+    "matched_open_interest",
+    "matched_funding_rate",
+    "matched_liq_buy_qty",
+    "matched_liq_sell_qty",
     "source_file",
     "terminal_decision_present",
     "cum_delta_24h",
@@ -315,6 +319,54 @@ def test_accepted_table_joins_close_outcomes_when_event_ts_is_naive_and_outcome_
     assert row["join_status"] == "exact"
     assert row["close_ts"] == "2026-01-02T01:00:00Z"
     assert result.matched_close_count == 1
+
+
+def test_review_outputs_include_matched_enriched_feed_fields(dataset_root: Path, tmp_path: Path):
+    _write_csv(
+        dataset_root / "events_context_2026-01-02.csv",
+        EVENTS_CONTEXT_FIELDS,
+        [
+            {
+                **{field: "" for field in EVENTS_CONTEXT_FIELDS},
+                "ts": "2026-01-02T00:10:00Z",
+                "day": "2026-01-02",
+                "event_type": "PEAK_EMIT",
+                "kind": "long",
+                "matched_open_interest": "12345",
+                "matched_funding_rate": "0.0001",
+                "matched_liq_buy_qty": "7",
+                "matched_liq_sell_qty": "8",
+            },
+            {
+                **{field: "" for field in EVENTS_CONTEXT_FIELDS},
+                "ts": "2026-01-02T00:20:00Z",
+                "day": "2026-01-02",
+                "event_type": "CANDIDATE_GATE_REJECT",
+                "kind": "short",
+                "reject_reason": "weak_delta",
+                "matched_open_interest": "54321",
+                "matched_funding_rate": "-0.0002",
+                "matched_liq_buy_qty": "9",
+                "matched_liq_sell_qty": "10",
+            },
+        ],
+    )
+
+    result = build_daily_review_package("2026-01-02", dataset_root, tmp_path)
+
+    with result.accepted_path.open("r", encoding="utf-8", newline="") as handle:
+        accepted_row = next(csv.DictReader(handle))
+    with result.reject_path.open("r", encoding="utf-8", newline="") as handle:
+        reject_row = next(csv.DictReader(handle))
+
+    assert accepted_row["matched_open_interest"] == "12345"
+    assert accepted_row["matched_funding_rate"] == "0.0001"
+    assert accepted_row["matched_liq_buy_qty"] == "7"
+    assert accepted_row["matched_liq_sell_qty"] == "8"
+    assert reject_row["matched_open_interest"] == "54321"
+    assert reject_row["matched_funding_rate"] == "-0.0002"
+    assert reject_row["matched_liq_buy_qty"] == "9"
+    assert reject_row["matched_liq_sell_qty"] == "10"
 
 
 def test_build_succeeds_without_close_outcomes_and_leaves_join_fields_empty(


### PR DESCRIPTION
### Motivation
- The enriched archived feed under `/opt/aitrader/feed/*.csv` is now the canonical archived-feed format and the analyzer must stop silently falling back to the legacy local sample feed.  
- Analysts need visibility of matched enrichment fields (`matched_open_interest`, `matched_funding_rate`, `matched_liq_buy_qty`, `matched_liq_sell_qty`) on review CSV surfaces, not just inside internal rows.  
- Tests and local contracts must assume the enriched schema as the primary format to keep the analyzer codebase consistent.  

### Description
- Remove legacy fallback by deleting `LEGACY_DEFAULT_FEED_GLOB` and change feed resolution so `_resolve_feed_files(pattern)` simply expands the provided glob and the CLI now fails loudly with `SystemExit` when the chosen feed glob matches no files.  
- Add `MATCHED_FEED_FIELDS` and `REVIEW_SHARED_FIELDS` in the review builder and use them when constructing/writing `accepted_event_context_YYYY-MM-DD.csv` and when ordering reject fields so the matched enrichment fields are present in accepted and reject review outputs.  
- Update type/test helpers to include the new matched-feed fields where needed, and adjust/extend focused tests to cover: canonical default feed resolution (no silent fallback), CLI failing when no feed files match, and matched enrichment fields appearing in accepted and reject review CSVs.  
- Update nearby analyzer docs/spec to state `/opt/aitrader/feed/*.csv` is the canonical default, that missing matches fail loudly, and that matched enrichment fields are surfaced on review artifacts.  
- Files changed: `deltascout/delta_analyzer/cli.py`, `deltascout/delta_analyzer/config.py`, `deltascout/delta_analyzer/modules/build_review_tables.py`, `deltascout/delta_analyzer/README.md`, `deltascout/delta_analyzer/Delta_Analyzer_Phase1_Spec.md`, `deltascout/delta_analyzer/delta_analyzer_implementation_plan_v1_1.md`, `deltascout/test/test_delta_analyzer_phase2_contracts.py`, `tests/offline/test_delta_analyzer_feed_reader.py`, `tests/offline/test_delta_analyzer_review_builder.py`.  

### Testing
- Ran focused test subset with: `PYTHONPATH=. pytest -q tests/offline/test_delta_analyzer_feed_reader.py tests/offline/test_delta_analyzer_review_builder.py deltascout/test/test_delta_analyzer_phase2_contracts.py`, which completed successfully with all tests passing (27 passed, 1 skipped).  
- Verified the CLI path now raises `SystemExit` with an explanatory message when the default feed glob matches no files via the added unit test.  
- Confirmed review-builder outputs include the four matched enrichment fields in accepted and reject CSV rows via a new test asserting those columns and values.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c140ebb350832396a6ff0ab1427584)