### PR TITLE
Default to canonical enriched daily feed, normalize feed rows, and add tests

### DIFF
--- a/deltascout/README.md
+++ b/deltascout/README.md
@@ -140,7 +140,7 @@ Builders:
 
 | Dataset area | Source | Builder |
 |--------------|--------|---------|
-| Rejects, baseline init, ownership misses, late peaks | DeltaScout archive + feed archive | `scripts.offline.build_phase1_derived` |
+| Rejects, baseline init, ownership misses, late peaks | DeltaScout archive + canonical enriched feed archive (`/opt/aitrader/feed/YYYY-MM-DD.csv` by default) | `scripts.offline.build_phase1_derived` |
 | Close outcomes | Primary: `trade_outcomes.jsonl`; fallback: executor artifacts | `scripts.offline.build_close_outcomes` |
 | Event context + daily review artifacts | DeltaScout archive + feed archive; optional close outcomes join for accepted review rows | `deltascout.delta_analyzer` |
 
@@ -153,7 +153,7 @@ Builders:
 Path:
 
 ```text
-/data/archive/feed/YYYY-MM-DD.csv
+/opt/aitrader/feed/YYYY-MM-DD.csv
 ```
 
 Properties:
@@ -161,7 +161,7 @@ Properties:
 - append-only
 - one file per UTC day
 - deduplicated by `Timestamp`
-- same schema as `aggregated.csv`
+- same core schema as `aggregated.csv`, with optional enriched columns
 - chronologically ordered
 
 Rules:
@@ -244,6 +244,8 @@ PYTHONPATH=/root/volume-alert /opt/aitrader/.venv/bin/python -m scripts.offline.
 PYTHONPATH=/root/volume-alert /opt/aitrader/.venv/bin/python -m scripts.offline.build_close_outcomes --date YYYY-MM-DD --input-root /data --output-root /data/archive/datasets
 PYTHONPATH=/root/volume-alert /opt/aitrader/.venv/bin/python -m deltascout.delta_analyzer.cli --build-review --date YYYY-MM-DD --input-root /data/archive/datasets --output-root /data/archive/datasets
 ```
+
+`build_phase1_derived` now reads the canonical enriched daily feed from `/opt/aitrader/feed/YYYY-MM-DD.csv` by default; use `--feed-file` only when you need an explicit override.
 
 Expected outputs:
 

--- a/scripts/offline/build_phase1_derived.py
+++ b/scripts/offline/build_phase1_derived.py
@@ -179,7 +179,7 @@ def derive_late_peak(df_feed: pd.DataFrame, df_evt: pd.DataFrame, source_date: s
 def run(args: argparse.Namespace) -> None:
     input_root = Path(args.input_root)
     archive_file = input_root / "archive" / "deltascout" / f"{args.date}.jsonl"
-    feed_file = Path(args.feed_file) if args.feed_file else input_root / "feed" / "aggregated.csv"
+    feed_file = Path(args.feed_file) if args.feed_file else Path("/opt/aitrader/feed") / f"{args.date}.csv"
 
     df_evt = _read_archive(archive_file)
     df_feed = load_feed(feed_file)
@@ -213,7 +213,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--date", required=True, help="Date in YYYY-MM-DD")
     p.add_argument("--input-root", default="/data", help="Root with archive/ and feed/")
     p.add_argument("--output-root", default="/data/archive/datasets", help="Output dataset root")
-    p.add_argument("--feed-file", default=None, help="Optional explicit feed CSV path")
+    p.add_argument("--feed-file", default=None, help="Optional explicit feed CSV path; default is /opt/aitrader/feed/YYYY-MM-DD.csv")
     p.add_argument("--roll-window", type=int, default=180, help="Rolling ownership window")
     p.add_argument("--owner-quantile", type=float, default=0.75, help="Quantile for meaningful abs(delta) threshold")
     p.add_argument("--late-lookback-rows", type=int, default=30, help="Lookback rows for move-start proxy")

--- a/scripts/offline/common.py
+++ b/scripts/offline/common.py
@@ -77,4 +77,4 @@ def load_feed(feed_path: Path) -> pd.DataFrame:
     df["price"] = pd.to_numeric(df["ClosePrice"], errors="coerce").fillna(pd.to_numeric(df["AvgPrice"], errors="coerce"))
     if df["delta"].isna().any() or df["price"].isna().any():
         raise OfflineBuildError("feed contains non-numeric BuyQty/SellQty/price values")
-    return df
+    return df.sort_values(["ts"], kind="mergesort").reset_index(drop=True)

--- a/tests/offline/test_phase1_builders.py
+++ b/tests/offline/test_phase1_builders.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pandas as pd
+import pytest
 
 from scripts.offline.build_close_outcomes import (
     _filter_df_by_date as _filter_close_df_by_date,
@@ -12,6 +13,7 @@ from scripts.offline.build_close_outcomes import (
     derive_close_outcomes,
 )
 from scripts.offline.build_phase1_derived import _filter_df_by_date, derive_reject_dataset
+from scripts.offline.common import OfflineBuildError, load_feed
 
 
 def test_reject_classification_soft_and_multi():
@@ -83,6 +85,112 @@ def test_date_scoping_filters_daily_rows():
     assert len(feed_scoped) == 1
     assert evt_scoped.iloc[0]["event_ts"].strftime("%Y-%m-%d") == "2026-01-01"
     assert feed_scoped.iloc[0]["ts"].strftime("%Y-%m-%d") == "2026-01-01"
+
+
+def test_load_feed_accepts_canonical_enriched_schema_and_sorts_rows(tmp_path):
+    feed = tmp_path / "2026-01-02.csv"
+    feed.write_text(
+        "\n".join(
+            [
+                "Timestamp,AvgPrice,ClosePrice,BuyQty,SellQty,OpenInterest,FundingRate,LiqBuyQty,LiqSellQty",
+                "2026-01-02T00:01:00Z,100,101,8,3,12345,0.0001,7,8",
+                "2026-01-02T00:00:00Z,99,100,5,1,12344,0.0002,1,2",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    out = load_feed(feed)
+
+    assert list(out["ts"].dt.strftime("%Y-%m-%dT%H:%M:%SZ")) == ["2026-01-02T00:00:00Z", "2026-01-02T00:01:00Z"]
+    assert list(out["delta"]) == [4, 5]
+    assert list(out["price"]) == [100, 101]
+
+
+def test_load_feed_accepts_core_columns_only_and_closeprice_fallbacks_to_avgprice(tmp_path):
+    feed = tmp_path / "2026-01-02.csv"
+    feed.write_text(
+        "\n".join(
+            [
+                "Timestamp,AvgPrice,ClosePrice,BuyQty,SellQty",
+                "2026-01-02T00:00:00Z,100,,5,2",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    out = load_feed(feed)
+
+    assert len(out) == 1
+    assert out.iloc[0]["delta"] == 3
+    assert out.iloc[0]["price"] == 100
+
+
+def test_load_feed_fails_loudly_on_invalid_timestamp(tmp_path):
+    feed = tmp_path / "2026-01-02.csv"
+    feed.write_text(
+        "\n".join(
+            [
+                "Timestamp,AvgPrice,ClosePrice,BuyQty,SellQty,OpenInterest,FundingRate,LiqBuyQty,LiqSellQty",
+                "not-a-ts,100,101,5,2,12345,0.0001,7,8",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(OfflineBuildError, match="invalid Timestamp"):
+        load_feed(feed)
+
+
+def test_load_feed_fails_loudly_on_invalid_required_numeric_fields(tmp_path):
+    feed = tmp_path / "2026-01-02.csv"
+    feed.write_text(
+        "\n".join(
+            [
+                "Timestamp,AvgPrice,ClosePrice,BuyQty,SellQty,OpenInterest,FundingRate,LiqBuyQty,LiqSellQty",
+                "2026-01-02T00:00:00Z,100,101,not-a-number,2,12345,0.0001,7,8",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(OfflineBuildError, match="non-numeric BuyQty/SellQty/price values"):
+        load_feed(feed)
+
+
+def test_enriched_feed_normalization_preserves_late_peak_behavior(tmp_path):
+    feed = tmp_path / "2026-01-02.csv"
+    feed.write_text(
+        "\n".join(
+            [
+                "Timestamp,AvgPrice,ClosePrice,BuyQty,SellQty,OpenInterest,FundingRate,LiqBuyQty,LiqSellQty",
+                "2026-01-02T00:02:00Z,102,102,6,1,12347,0.0001,7,8",
+                "2026-01-02T00:00:00Z,100,100,5,1,12345,0.0001,7,8",
+                "2026-01-02T00:01:00Z,98,98,4,1,12346,0.0001,7,8",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    df_feed = load_feed(feed)
+    peaks = pd.DataFrame(
+        [
+            {"event": "PEAK_EMIT", "event_ts": pd.Timestamp("2026-01-02T00:02:00Z"), "kind": "long", "price": 102.0, "seq": 1},
+        ]
+    )
+
+    from scripts.offline.build_phase1_derived import derive_late_peak
+
+    out = derive_late_peak(df_feed, peaks, "2026-01-02", lookback_rows=3)
+
+    assert len(out) == 1
+    assert out.iloc[0]["move_start_ts"] == pd.Timestamp("2026-01-02T00:01:00Z")
+    assert out.iloc[0]["latency_min"] == 1.0
+    assert out.iloc[0]["move_size"] == 4.0
 
 
 def test_close_dedup_state_and_log_duplicate():


### PR DESCRIPTION
### Motivation

- Standardize the offline builders to read the canonical enriched daily feed location instead of the old archive path.  
- Ensure the feed loader returns chronologically ordered rows so downstream builders (e.g. `derive_late_peak`) behave deterministically.  
- Validate enriched-feed compatibility and error handling with automated tests to catch schema or data quality regressions.  

### Description

- Change default feed location in `scripts/offline/build_phase1_derived.py` to `/opt/aitrader/feed/YYYY-MM-DD.csv` and update the CLI `--feed-file` help text.  
- Update documentation in `deltascout/README.md` and the feed contract to reference the canonical enriched feed path and note the default behavior.  
- Normalize feed parsing in `scripts/offline/common.py` by sorting returned DataFrame by `ts` (`load_feed` now returns a mergesort-sorted, reindexed DataFrame).  
- Add unit tests in `tests/offline/test_phase1_builders.py` to cover `load_feed` ordering, price fallback logic, invalid timestamp and numeric-field error cases, and preservation of `derive_late_peak` behavior with enriched feeds.  

### Testing

- Ran `pytest tests/offline/test_phase1_builders.py` which includes the new `load_feed` and late-peak normalization tests.  
- All added and existing offline builder tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c163bfe0848323bfda6ae4c8223db5)