### PR TITLE
Redesign phase1 derived feed intake contract

### DIFF
--- a/deltascout/README.md
+++ b/deltascout/README.md
@@ -140,7 +140,7 @@ Builders:
 
 | Dataset area | Source | Builder |
 |--------------|--------|---------|
-| Rejects, baseline init, ownership misses, late peaks | DeltaScout archive + canonical enriched feed archive (`/opt/aitrader/feed/YYYY-MM-DD.csv` by default) | `scripts.offline.build_phase1_derived` |
+| Rejects, baseline init, ownership misses, late peaks | DeltaScout archive + canonical enriched daily feed, resolved from `--feed-file`, `--feed-root/YYYY-MM-DD.csv`, or `--input-root/feed/YYYY-MM-DD.csv` | `scripts.offline.build_phase1_derived` |
 | Close outcomes | Primary: `trade_outcomes.jsonl`; fallback: executor artifacts | `scripts.offline.build_close_outcomes` |
 | Event context + daily review artifacts | DeltaScout archive + feed archive; optional close outcomes join for accepted review rows | `deltascout.delta_analyzer` |
 
@@ -150,10 +150,10 @@ Builders:
 
 ### Feed archive contract
 
-Path:
+Default self-contained path:
 
 ```text
-/opt/aitrader/feed/YYYY-MM-DD.csv
+INPUT_ROOT/feed/YYYY-MM-DD.csv
 ```
 
 Properties:
@@ -163,6 +163,7 @@ Properties:
 - deduplicated by `Timestamp`
 - same core schema as `aggregated.csv`, with optional enriched columns
 - chronologically ordered
+- builder normalization uses `Timestamp -> ts` (UTC), `BuyQty - SellQty -> delta`, and `ClosePrice` with row-level `AvgPrice` fallback -> `price`
 
 Rules:
 
@@ -245,7 +246,13 @@ PYTHONPATH=/root/volume-alert /opt/aitrader/.venv/bin/python -m scripts.offline.
 PYTHONPATH=/root/volume-alert /opt/aitrader/.venv/bin/python -m deltascout.delta_analyzer.cli --build-review --date YYYY-MM-DD --input-root /data/archive/datasets --output-root /data/archive/datasets
 ```
 
-`build_phase1_derived` now reads the canonical enriched daily feed from `/opt/aitrader/feed/YYYY-MM-DD.csv` by default; use `--feed-file` only when you need an explicit override.
+`build_phase1_derived` resolves feed input in this order:
+
+1. `--feed-file` explicit file override
+2. `--feed-root/YYYY-MM-DD.csv`
+3. self-contained `--input-root/feed/YYYY-MM-DD.csv`
+
+This keeps copied replay trees self-contained by default while still supporting production-style runs against an explicit external canonical feed root.
 
 Expected outputs:
 

--- a/deltascout/research_material/runbooks/post_close_watcher.md
+++ b/deltascout/research_material/runbooks/post_close_watcher.md
@@ -15,6 +15,7 @@ It does not use `executor.log`, `executor_state.json`, generated close outcome C
 - Processes only one latest close marker at a time, using `trade_key` when present and a timestamp/reason/side fallback when it is not.
 - Runs, in order, `build_phase1_derived`, `build_close_outcomes`, and `delta_analyzer --build-review` for the discovered UTC close date.
 - Updates `/root/volume-alert/data/state/post_close_watcher_state.json` only after all three steps succeed.
+- `build_phase1_derived` is replay-safe by default because it resolves feed input from its own `--input-root/feed/YYYY-MM-DD.csv` unless `--feed-root` or `--feed-file` is supplied explicitly.
 
 ## Intended usage
 

--- a/scripts/offline/build_phase1_derived.py
+++ b/scripts/offline/build_phase1_derived.py
@@ -10,6 +10,9 @@ import pandas as pd
 from scripts.offline.common import OfflineBuildError, load_feed, read_jsonl, sort_and_order, write_dataframe
 
 
+DEFAULT_RELATIVE_FEED_DIR = Path("feed")
+
+
 def _read_archive(archive_file: Path) -> pd.DataFrame:
     events = read_jsonl(archive_file)
     if not events:
@@ -176,10 +179,17 @@ def derive_late_peak(df_feed: pd.DataFrame, df_evt: pd.DataFrame, source_date: s
     return sort_and_order(pd.DataFrame(out_rows), ["event_ts", "seq"], ["source_date", "event_ts", "kind", "seq", "move_start_ts", "latency_min", "move_size", "peak_price", "reference_price", "lookback_rows"])
 
 
+def resolve_feed_file(*, date: str, input_root: Path, feed_root: str | None, feed_file: str | None) -> Path:
+    if feed_file:
+        return Path(feed_file)
+    base_root = Path(feed_root) if feed_root else input_root / DEFAULT_RELATIVE_FEED_DIR
+    return base_root / f"{date}.csv"
+
+
 def run(args: argparse.Namespace) -> None:
     input_root = Path(args.input_root)
     archive_file = input_root / "archive" / "deltascout" / f"{args.date}.jsonl"
-    feed_file = Path(args.feed_file) if args.feed_file else Path("/opt/aitrader/feed") / f"{args.date}.csv"
+    feed_file = resolve_feed_file(date=args.date, input_root=input_root, feed_root=args.feed_root, feed_file=args.feed_file)
 
     df_evt = _read_archive(archive_file)
     df_feed = load_feed(feed_file)
@@ -211,9 +221,10 @@ def run(args: argparse.Namespace) -> None:
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description="Build DeltaScout Phase 1 derived datasets (offline only)")
     p.add_argument("--date", required=True, help="Date in YYYY-MM-DD")
-    p.add_argument("--input-root", default="/data", help="Root with archive/ and feed/")
+    p.add_argument("--input-root", default="/data", help="Root with archive/ and self-contained feed/ by default")
     p.add_argument("--output-root", default="/data/archive/datasets", help="Output dataset root")
-    p.add_argument("--feed-file", default=None, help="Optional explicit feed CSV path; default is /opt/aitrader/feed/YYYY-MM-DD.csv")
+    p.add_argument("--feed-root", default=None, help="Optional external feed root containing YYYY-MM-DD.csv files")
+    p.add_argument("--feed-file", default=None, help="Optional explicit feed CSV path; highest-priority source override")
     p.add_argument("--roll-window", type=int, default=180, help="Rolling ownership window")
     p.add_argument("--owner-quantile", type=float, default=0.75, help="Quantile for meaningful abs(delta) threshold")
     p.add_argument("--late-lookback-rows", type=int, default=30, help="Lookback rows for move-start proxy")

--- a/scripts/offline/common.py
+++ b/scripts/offline/common.py
@@ -59,13 +59,7 @@ def load_feed(feed_path: Path) -> pd.DataFrame:
     if not feed_path.exists():
         raise OfflineBuildError(f"missing feed file: {feed_path}")
     df = pd.read_csv(feed_path)
-    required = [
-        "Timestamp",
-        "BuyQty",
-        "SellQty",
-        "AvgPrice",
-        "ClosePrice",
-    ]
+    required = ["Timestamp", "BuyQty", "SellQty", "AvgPrice", "ClosePrice"]
     miss = [c for c in required if c not in df.columns]
     if miss:
         raise OfflineBuildError(f"feed missing columns {miss} in {feed_path}")
@@ -73,8 +67,16 @@ def load_feed(feed_path: Path) -> pd.DataFrame:
     df["ts"] = _parse_ts(df["Timestamp"])
     if df["ts"].isna().any():
         raise OfflineBuildError(f"feed contains invalid Timestamp rows in {feed_path}")
-    df["delta"] = pd.to_numeric(df["BuyQty"], errors="coerce") - pd.to_numeric(df["SellQty"], errors="coerce")
-    df["price"] = pd.to_numeric(df["ClosePrice"], errors="coerce").fillna(pd.to_numeric(df["AvgPrice"], errors="coerce"))
-    if df["delta"].isna().any() or df["price"].isna().any():
-        raise OfflineBuildError("feed contains non-numeric BuyQty/SellQty/price values")
+    buy_qty = pd.to_numeric(df["BuyQty"], errors="coerce")
+    sell_qty = pd.to_numeric(df["SellQty"], errors="coerce")
+    avg_price = pd.to_numeric(df["AvgPrice"], errors="coerce")
+    close_price = pd.to_numeric(df["ClosePrice"], errors="coerce")
+    if buy_qty.isna().any() or sell_qty.isna().any():
+        raise OfflineBuildError(f"feed contains invalid BuyQty/SellQty rows in {feed_path}")
+    if (avg_price.isna() & close_price.isna()).any():
+        raise OfflineBuildError(f"feed contains invalid ClosePrice/AvgPrice rows in {feed_path}")
+    df["delta"] = buy_qty - sell_qty
+    df["price"] = close_price.fillna(avg_price)
+    if df["price"].isna().any():
+        raise OfflineBuildError(f"feed contains invalid ClosePrice/AvgPrice rows in {feed_path}")
     return df.sort_values(["ts"], kind="mergesort").reset_index(drop=True)

--- a/tests/offline/test_phase1_builders.py
+++ b/tests/offline/test_phase1_builders.py
@@ -12,8 +12,15 @@ from scripts.offline.build_close_outcomes import (
     _load_peak_events,
     derive_close_outcomes,
 )
-from scripts.offline.build_phase1_derived import _filter_df_by_date, derive_reject_dataset
+from scripts.offline.build_phase1_derived import _filter_df_by_date, derive_reject_dataset, resolve_feed_file, run
 from scripts.offline.common import OfflineBuildError, load_feed
+
+
+def _read_output_dataset(path_base):
+    parquet_path = path_base.with_suffix(".parquet")
+    if parquet_path.exists():
+        return pd.read_parquet(parquet_path)
+    return pd.read_csv(path_base.with_suffix(".csv"))
 
 
 def test_reject_classification_soft_and_multi():
@@ -158,8 +165,67 @@ def test_load_feed_fails_loudly_on_invalid_required_numeric_fields(tmp_path):
         encoding="utf-8",
     )
 
-    with pytest.raises(OfflineBuildError, match="non-numeric BuyQty/SellQty/price values"):
+    with pytest.raises(OfflineBuildError, match="invalid BuyQty/SellQty"):
         load_feed(feed)
+
+
+def test_load_feed_fails_loudly_when_closeprice_and_avgprice_are_both_invalid(tmp_path):
+    feed = tmp_path / "2026-01-02.csv"
+    feed.write_text(
+        "\n".join(
+            [
+                "Timestamp,AvgPrice,ClosePrice,BuyQty,SellQty,OpenInterest,FundingRate,LiqBuyQty,LiqSellQty",
+                "2026-01-02T00:00:00Z,,,5,2,12345,0.0001,7,8",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(OfflineBuildError, match="invalid ClosePrice/AvgPrice"):
+        load_feed(feed)
+
+
+def test_resolve_feed_file_priority_order(tmp_path):
+    input_root = tmp_path / "input"
+    explicit_file = tmp_path / "explicit.csv"
+    external_root = tmp_path / "external"
+
+    resolved = resolve_feed_file(
+        date="2026-01-02",
+        input_root=input_root,
+        feed_root=str(external_root),
+        feed_file=str(explicit_file),
+    )
+
+    assert resolved == explicit_file
+
+
+def test_resolve_feed_file_uses_explicit_feed_root_when_feed_file_missing(tmp_path):
+    input_root = tmp_path / "input"
+    external_root = tmp_path / "external"
+
+    resolved = resolve_feed_file(
+        date="2026-01-02",
+        input_root=input_root,
+        feed_root=str(external_root),
+        feed_file=None,
+    )
+
+    assert resolved == external_root / "2026-01-02.csv"
+
+
+def test_resolve_feed_file_defaults_to_self_contained_input_root(tmp_path):
+    input_root = tmp_path / "input"
+
+    resolved = resolve_feed_file(
+        date="2026-01-02",
+        input_root=input_root,
+        feed_root=None,
+        feed_file=None,
+    )
+
+    assert resolved == input_root / "feed" / "2026-01-02.csv"
 
 
 def test_enriched_feed_normalization_preserves_late_peak_behavior(tmp_path):
@@ -191,6 +257,65 @@ def test_enriched_feed_normalization_preserves_late_peak_behavior(tmp_path):
     assert out.iloc[0]["move_start_ts"] == pd.Timestamp("2026-01-02T00:01:00Z")
     assert out.iloc[0]["latency_min"] == 1.0
     assert out.iloc[0]["move_size"] == 4.0
+
+
+def test_run_uses_self_contained_feed_by_default_and_preserves_output_parity(tmp_path):
+    input_root = tmp_path / "data"
+    archive_dir = input_root / "archive" / "deltascout"
+    feed_dir = input_root / "feed"
+    output_root = tmp_path / "out"
+    archive_dir.mkdir(parents=True)
+    feed_dir.mkdir(parents=True)
+
+    (archive_dir / "2026-01-02.jsonl").write_text(
+        "\n".join(
+            [
+                '{"event":"DELTA_MAX","ts":"2026-01-02T00:02:00Z","seq":1,"delta":5,"price":102}',
+                '{"event":"PEAK_EMIT","ts":"2026-01-02T00:02:00Z","seq":2,"kind":"long","price":102}',
+                '{"event":"CANDIDATE_COMPARISON_REJECT","ts":"2026-01-02T00:03:00Z","seq":3,"kind":"long","reject_reason":"no_prev_peak"}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (feed_dir / "2026-01-02.csv").write_text(
+        "\n".join(
+            [
+                "Timestamp,AvgPrice,ClosePrice,BuyQty,SellQty",
+                "2026-01-02T00:02:00Z,102,102,6,1",
+                "2026-01-02T00:00:00Z,100,100,5,1",
+                "2026-01-02T00:01:00Z,98,98,4,1",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    run(
+        type(
+            "Args",
+            (),
+            {
+                "date": "2026-01-02",
+                "input_root": str(input_root),
+                "output_root": str(output_root),
+                "feed_root": None,
+                "feed_file": None,
+                "roll_window": 3,
+                "owner_quantile": 0.75,
+                "late_lookback_rows": 3,
+                "soft_vwap_margin": 50.0,
+                "soft_imb_margin": 0.01,
+            },
+        )()
+    )
+
+    baseline = _read_output_dataset(output_root / "baseline_init_2026-01-02")
+    late_peak = _read_output_dataset(output_root / "late_peak_2026-01-02")
+
+    assert baseline["reject_reason"].tolist() == ["no_prev_peak"]
+    assert late_peak.loc[0, "move_start_ts"] == "2026-01-02 00:01:00+00:00"
+    assert late_peak.loc[0, "latency_min"] == 1.0
 
 
 def test_close_dedup_state_and_log_duplicate():


### PR DESCRIPTION
### Motivation
- Eliminate hidden host-path assumptions and make Phase 1 builder feed intake self-contained and replay-safe.
- Support the canonical enriched daily feed via a normalization adapter while preserving existing derived artifact semantics.
- Make feed source resolution explicit so offline replay trees are not silently contaminated by external feed locations.

### Description
- Introduce explicit feed resolution with priority: `--feed-file` (explicit file), `--feed-root` + `{date}.csv`, then self-contained `--input-root/feed/{date}.csv`, implemented via `resolve_feed_file` and `DEFAULT_RELATIVE_FEED_DIR` in `build_phase1_derived.py`.
- Add `--feed-root` CLI option and clarify `--input-root` help text; keep downstream derivation behavior unchanged.
- Harden canonical enriched feed normalization in `scripts/offline/common.py::load_feed` to produce the minimal internal contract (`ts`, `delta`, `price`), with UTC timestamp parsing, `delta = BuyQty - SellQty`, `price = ClosePrice` fallback to `AvgPrice`, deterministic sort-by-`ts`, and fail-loud errors on invalid timestamps or numeric fields.
- Add focused unit tests covering feed resolution priority, self-contained default behavior, enriched-feed normalization (sorting, numeric/fallback checks), fail-loud cases for invalid timestamps/numerics, and a representative run that verifies output parity-style artifacts are produced.
- Update nearby docs to describe the new source contract and replay-safe default behavior (`deltascout/README.md`, post-close watcher runbook).

### Testing
- Ran compile check: `python -m py_compile scripts/offline/build_phase1_derived.py scripts/offline/common.py tests/offline/test_phase1_builders.py` — succeeded.
- Attempted to run `pytest -q tests/offline/test_phase1_builders.py`, but the container lacks `pandas` and network install is blocked by a proxy, so tests could not be executed here; test files were added/updated to exercise: `resolve_feed_file` priority, canonical normalization and sorting, fail-loud behavior on invalid Timestamp/BuyQty/SellQty/price fields, and a representative `run(...)` parity-style check that writes the expected derived CSV/Parquet outputs.

Files changed:
- `scripts/offline/build_phase1_derived.py` (feed resolution + CLI args)
- `scripts/offline/common.py` (feed normalization + stricter validation)
- `tests/offline/test_phase1_builders.py` (new/updated tests)
- `deltascout/README.md` (feed contract docs)
- `deltascout/research_material/runbooks/post_close_watcher.md` (note on replay-safe default)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c172f2d4448323b89ff07fbb808b5e)