### PR TITLE
Implement M2.6 process-chain bridge: candidate / reference / cluster outputs and CLI

### DIFF
--- a/deltascout/delta_analyzer/README.md
+++ b/deltascout/delta_analyzer/README.md
@@ -90,6 +90,18 @@ Phase M2.5 currently includes:
 
 It remains feed-native and additive. It does not implement taxonomy, process-phase logic, setup validation, or trade-close logic.
 
+## Phase M2.6 Scope
+
+Phase M2.6 adds a research-only process-chain bridge above `minute_events_outcomes`.
+
+Phase M2.6 currently includes deterministic derived outputs:
+
+- `minute_event_chain_candidates`
+- `minute_event_chain_reference_cases`
+- `chain_cluster_summaries`
+
+This layer remains provisional and hypothesis-driven. It is not final taxonomy or full process-engine truth.
+
 ## Not Implemented
 
 `delta_analyzer` still does not implement:
@@ -124,6 +136,8 @@ python -m deltascout.delta_analyzer.cli --dataset minute_events_mechanics --date
 python -m deltascout.delta_analyzer.cli --dataset minute_events_outcomes
 python -m deltascout.delta_analyzer.cli --dataset minute_events_outcomes --date YYYY-MM-DD --output-root /data/archive/datasets
 python -m deltascout.delta_analyzer.cli --build-review --date YYYY-MM-DD --input-root /data/archive/datasets --output-root /data/archive/datasets
+python -m deltascout.delta_analyzer.cli --build-m2-6 --date YYYY-MM-DD --input-root /data/archive/datasets --output-root /data/archive/datasets
+python -m deltascout.delta_analyzer.cli --build-m2-6 --date-from YYYY-MM-DD --date-to YYYY-MM-DD --input-root /data/archive/datasets --output-root /data/archive/datasets
 ```
 
 The default archive glob still points to the local research-material archive sample. The default feed glob is now the canonical enriched archive path `/opt/aitrader/feed/*.csv`, and the analyzer fails loudly when that glob matches no files. Any explicit `--feed-glob` override still wins.

--- a/deltascout/delta_analyzer/cli.py
+++ b/deltascout/delta_analyzer/cli.py
@@ -15,6 +15,7 @@ from .modules.build_events_context import build_events_context_dataset
 from .modules.build_minute_events_base import build_minute_events_base_dataset
 from .modules.build_minute_events_mechanics import build_minute_events_mechanics_dataset
 from .modules.build_minute_events_outcomes import build_minute_events_outcomes_dataset
+from .modules.build_minute_event_process_chain import build_m2_6_outputs_for_scope
 from .modules.build_review_tables import ReviewBuildError, build_daily_review_package
 from .modules.feed_reader import read_feed_rows
 from .modules.integrity_checks import run_integrity_checks
@@ -60,7 +61,10 @@ def build_parser() -> argparse.ArgumentParser:
         help="Highest dataset layer to build. events_context also builds events_base.",
     )
     parser.add_argument("--build-review", action="store_true", help="Build Phase 2.5 daily review artifacts from dataset CSV inputs.")
+    parser.add_argument("--build-m2-6", action="store_true", help="Build M2.6 process-chain bridge outputs from minute datasets.")
     parser.add_argument("--date", help="UTC date for review build mode in YYYY-MM-DD format.")
+    parser.add_argument("--date-from", help="Start UTC date for range builds in YYYY-MM-DD format.")
+    parser.add_argument("--date-to", help="End UTC date for range builds in YYYY-MM-DD format.")
     parser.add_argument("--input-root", default=DEFAULT_DATASET_ROOT, help="Dataset root for review-builder inputs.")
     parser.add_argument("--output-root", default=DEFAULT_DATASET_ROOT, help="Dataset root for review-builder outputs.")
     return parser
@@ -143,6 +147,26 @@ def main() -> None:
         print(f"reject_rows={result.reject_count}")
         print(f"matched_accepted_close_rows={result.matched_close_count}")
         print(f"output_dir={result.output_dir}")
+        return
+    if args.build_m2_6:
+        if args.date and (args.date_from or args.date_to):
+            raise SystemExit("--date cannot be combined with --date-from/--date-to in --build-m2-6 mode")
+        if args.date_from and not args.date_to:
+            args.date_to = args.date_from
+        try:
+            result = build_m2_6_outputs_for_scope(
+                input_root=args.input_root,
+                output_root=args.output_root,
+                date=args.date,
+                date_from=args.date_from,
+                date_to=args.date_to,
+            )
+        except ValueError as exc:
+            raise SystemExit(str(exc)) from exc
+        print("Delta Analyzer M2.6 Build")
+        print(f"minute_event_chain_candidates_csv={result['candidates']}")
+        print(f"minute_event_chain_reference_cases_csv={result['reference_cases']}")
+        print(f"chain_cluster_summaries_csv={result['cluster_summaries']}")
         return
 
     feed_files = _resolve_feed_files(args.feed_glob)
@@ -254,4 +278,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/deltascout/delta_analyzer/modules/build_minute_event_process_chain.py
+++ b/deltascout/delta_analyzer/modules/build_minute_event_process_chain.py
@@ -1,0 +1,486 @@
+from __future__ import annotations
+
+import csv
+from dataclasses import asdict
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from ..types import ChainClusterSummaryRow, MinuteEventChainCandidateRow, MinuteEventChainReferenceCaseRow
+
+SUPPORTED_FAMILIES = {"F1", "F2"}
+SUPPORTED_CHAIN_ROLES = {"seed", "release", "continuation", "late_exhaustion", "unknown"}
+WINDOW_GAP_MINUTES = 20
+
+
+def build_m2_6_outputs(
+    mechanics_rows: list[dict[str, str]],
+    outcomes_rows: list[dict[str, str]],
+) -> tuple[list[MinuteEventChainCandidateRow], list[MinuteEventChainReferenceCaseRow], list[ChainClusterSummaryRow]]:
+    merged = _build_merged_rows(mechanics_rows, outcomes_rows)
+    candidates = _build_candidates(merged)
+    reference_cases = build_reference_cases(candidates)
+    cluster_summaries = build_cluster_summaries(candidates)
+    return candidates, reference_cases, cluster_summaries
+
+
+def build_m2_6_outputs_for_scope(
+    *,
+    input_root: str,
+    output_root: str,
+    date: str | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+) -> dict[str, Path]:
+    scope_start, scope_end = _resolve_scope_dates(input_root, date=date, date_from=date_from, date_to=date_to)
+    mechanics_rows = _load_rows_for_scope(Path(input_root), "minute_events_mechanics", scope_start, scope_end)
+    outcomes_rows = _load_rows_for_scope(Path(input_root), "minute_events_outcomes", scope_start, scope_end)
+    candidates, reference_cases, cluster_summaries = build_m2_6_outputs(mechanics_rows, outcomes_rows)
+
+    suffix = f"{scope_start}_to_{scope_end}"
+    out_dir = Path(output_root) / "m2_6"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    candidates_path = out_dir / f"minute_event_chain_candidates_{suffix}.csv"
+    reference_cases_path = out_dir / f"minute_event_chain_reference_cases_{suffix}.csv"
+    cluster_summaries_path = out_dir / f"chain_cluster_summaries_{suffix}.csv"
+
+    _write_dataclass_csv(candidates, candidates_path, MinuteEventChainCandidateRow)
+    _write_dataclass_csv(reference_cases, reference_cases_path, MinuteEventChainReferenceCaseRow)
+    _write_dataclass_csv(cluster_summaries, cluster_summaries_path, ChainClusterSummaryRow)
+
+    return {
+        "candidates": candidates_path,
+        "reference_cases": reference_cases_path,
+        "cluster_summaries": cluster_summaries_path,
+        "scope_start": Path(scope_start),
+        "scope_end": Path(scope_end),
+    }
+
+
+def build_reference_cases(candidates: list[MinuteEventChainCandidateRow]) -> list[MinuteEventChainReferenceCaseRow]:
+    if not candidates:
+        return []
+    ranked = sorted(candidates, key=lambda row: (row.day, row.ts, row.family_hint, row.direction))
+    by_family = {"F1": [], "F2": []}
+    for row in ranked:
+        if row.family_hint in by_family:
+            by_family[row.family_hint].append(row)
+
+    selected: dict[tuple[datetime, str, str], MinuteEventChainCandidateRow] = {}
+
+    for family in ("F1", "F2"):
+        rows = by_family[family]
+        if not rows:
+            continue
+        strong = max(rows, key=_reference_strength_score)
+        weak = min(rows, key=_reference_strength_score)
+        selected[(strong.ts, strong.direction, strong.family_hint)] = strong
+        selected[(weak.ts, weak.direction, weak.family_hint)] = weak
+
+    late_rows = [row for row in ranked if row.chain_role_hypothesis == "late_exhaustion"]
+    unknown_rows = [row for row in ranked if row.chain_role_hypothesis == "unknown"]
+    if late_rows:
+        chosen = max(late_rows, key=lambda row: abs(row.adverse_max_30m or 0.0))
+        selected[(chosen.ts, chosen.direction, chosen.family_hint)] = chosen
+    if unknown_rows:
+        chosen = unknown_rows[0]
+        selected[(chosen.ts, chosen.direction, chosen.family_hint)] = chosen
+
+    output: list[MinuteEventChainReferenceCaseRow] = []
+    for row in sorted(selected.values(), key=lambda item: (item.day, item.ts, item.family_hint, item.direction)):
+        confidence = "medium" if row.chain_role_hypothesis in {"seed", "release", "continuation"} else "low"
+        output.append(
+            MinuteEventChainReferenceCaseRow(
+                ts=row.ts,
+                day=row.day,
+                direction=row.direction,
+                family_hint=row.family_hint,
+                chain_role_label=f"provisional_{row.chain_role_hypothesis}",
+                role_confidence=confidence,
+                phase_marker_vs_entry_candidate="entry_candidate" if row.candidate_rank_in_window == 1 else "post_entry_chain",
+                reference_window_id=row.reference_window_id,
+                pre_window_summary=(
+                    f"pre: cum_delta_60m={_fmt_num(row.cum_delta_60m)}; ret_15m={_fmt_num(row.ret_15m)}; "
+                    f"vwap_side={row.price_vs_vwap_side}"
+                ),
+                post_window_summary=(
+                    f"post: ret_fwd_30m={_fmt_num(row.ret_fwd_30m)}; ret_fwd_60m={_fmt_num(row.ret_fwd_60m)}; "
+                    f"favorable_30m={_fmt_num(row.favorable_max_30m)}"
+                ),
+                move_followthrough_notes=(
+                    "followthrough supportive" if (row.favorable_max_30m or 0.0) >= (row.adverse_max_30m or 0.0) else "followthrough weak"
+                ),
+                invalidating_notes=(
+                    "adverse excursion dominates" if (row.adverse_max_30m or 0.0) > (row.favorable_max_30m or 0.0) else "no strong invalidation observed"
+                ),
+            )
+        )
+    return output
+
+
+def build_cluster_summaries(candidates: list[MinuteEventChainCandidateRow]) -> list[ChainClusterSummaryRow]:
+    if not candidates:
+        return []
+    grouped: dict[str, list[MinuteEventChainCandidateRow]] = {}
+    for row in candidates:
+        grouped.setdefault(row.reference_window_id, []).append(row)
+
+    output: list[ChainClusterSummaryRow] = []
+    for window_id in sorted(grouped):
+        rows = sorted(grouped[window_id], key=lambda row: row.ts)
+        role_set = {row.chain_role_hypothesis for row in rows}
+        if len(rows) == 1 and rows[0].chain_role_hypothesis == "seed":
+            pattern = "seed_only"
+        elif any(row.chain_role_hypothesis == "seed" for row in rows) and any(
+            row.chain_role_hypothesis == "release" for row in rows
+        ):
+            pattern = "seed_then_release"
+        elif len(rows) == 1 and rows[0].chain_role_hypothesis == "release":
+            pattern = "release_only"
+        elif role_set == {"continuation"}:
+            pattern = "continuation_cluster"
+        elif "late_exhaustion" in role_set:
+            pattern = "late_mixed"
+        else:
+            pattern = "ambiguous"
+
+        family_counts: dict[str, int] = {}
+        for row in rows:
+            family_counts[row.family_hint] = family_counts.get(row.family_hint, 0) + 1
+        mix = "|".join(f"{name}:{family_counts[name]}" for name in sorted(family_counts))
+
+        long_count = sum(1 for row in rows if row.direction == "long")
+        short_count = sum(1 for row in rows if row.direction == "short")
+        directional_bias = "long" if long_count > short_count else "short" if short_count > long_count else "mixed"
+
+        output.append(
+            ChainClusterSummaryRow(
+                reference_window_id=window_id,
+                day=rows[0].day,
+                directional_bias=directional_bias,
+                candidate_count=len(rows),
+                family_mix=mix,
+                earliest_ts=rows[0].ts,
+                latest_ts=rows[-1].ts,
+                provisional_chain_pattern=pattern,
+                contains_seed_flag="seed" in role_set,
+                contains_release_flag="release" in role_set,
+                contains_continuation_flag="continuation" in role_set,
+                contains_late_flag="late_exhaustion" in role_set,
+            )
+        )
+    return output
+
+
+def _build_candidates(merged_rows: list[dict[str, object]]) -> list[MinuteEventChainCandidateRow]:
+    if not merged_rows:
+        return []
+    selected: list[dict[str, object]] = []
+    for row in merged_rows:
+        family_hint = _assign_family_hint(row)
+        if family_hint not in SUPPORTED_FAMILIES:
+            continue
+        row = dict(row)
+        row["family_hint"] = family_hint
+        selected.append(row)
+
+    selected.sort(key=lambda row: (str(row["day"]), row["ts"], str(row.get("direction", "")), str(row.get("family_hint", ""))))
+
+    grouped: dict[tuple[str, str], list[dict[str, object]]] = {}
+    for row in selected:
+        grouped.setdefault((str(row["day"]), str(row["direction"])), []).append(row)
+
+    for (_, direction), rows in grouped.items():
+        window_num = 0
+        last_ts: datetime | None = None
+        last_window_num = 0
+        for idx, row in enumerate(rows):
+            ts = row["ts"]
+            if last_ts is None or (ts - last_ts).total_seconds() / 60.0 > WINDOW_GAP_MINUTES:
+                window_num += 1
+                last_window_num = window_num
+                rank = 1
+            else:
+                rank = sum(1 for prior in rows[:idx] if prior.get("reference_window_id") == f"{row['day']}_{direction}_w{last_window_num:03d}") + 1
+            row["reference_window_id"] = f"{row['day']}_{direction}_w{last_window_num:03d}"
+            row["candidate_rank_in_window"] = rank
+            row["minutes_from_prev_candidate_same_family"] = _minutes_since_prev(rows, idx, family_filter=str(row["family_hint"]))
+            row["minutes_from_prev_candidate_any_family"] = _minutes_since_prev(rows, idx, family_filter=None)
+            last_ts = ts
+
+    by_window: dict[str, list[dict[str, object]]] = {}
+    for row in selected:
+        by_window.setdefault(str(row["reference_window_id"]), []).append(row)
+
+    for rows in by_window.values():
+        rows.sort(key=lambda row: row["ts"])
+        for idx, row in enumerate(rows):
+            row["chain_role_hypothesis"] = _assign_chain_role(row, idx)
+            row["reference_case_flag"] = False
+            row["notes"] = ""
+
+    candidates = [
+        MinuteEventChainCandidateRow(
+            ts=row["ts"],
+            day=str(row["day"]),
+            direction=str(row["direction"]),
+            family_hint=str(row["family_hint"]),
+            chain_role_hypothesis=str(row["chain_role_hypothesis"]),
+            reference_window_id=str(row["reference_window_id"]),
+            price_vs_vwap_side=str(row.get("price_vs_vwap_side", "at_or_unknown")),
+            cum_delta_24h=_as_float(row.get("cum_delta_24h")),
+            cum_delta_180m=_as_float(row.get("cum_delta_180m")),
+            cum_delta_60m=_as_float(row.get("cum_delta_60m")),
+            ret_15m=_as_float(row.get("ret_15m")),
+            ret_60m=_as_float(row.get("ret_60m")),
+            delta_1m=_as_float(row.get("delta_1m")),
+            vol_1m=_as_float(row.get("vol_1m")),
+            imbalance_1m=_as_float(row.get("imbalance_1m")),
+            delta_price_alignment_1m=str(row.get("delta_price_alignment_1m", "flat_or_unknown")),
+            delta_price_efficiency_1m=_as_float(row.get("delta_price_efficiency_1m")),
+            dist_from_vwap=_as_float(row.get("dist_from_vwap")),
+            open_interest=_as_float(row.get("open_interest")),
+            funding_rate=_as_float(row.get("funding_rate")),
+            liq_buy_qty=_as_float(row.get("liq_buy_qty")),
+            liq_sell_qty=_as_float(row.get("liq_sell_qty")),
+            ret_fwd_30m=_as_float(row.get("ret_fwd_30m")),
+            ret_fwd_60m=_as_float(row.get("ret_fwd_60m")),
+            favorable_max_30m=_as_float(row.get("favorable_max_30m")),
+            adverse_max_30m=_as_float(row.get("adverse_max_30m")),
+            notes=str(row.get("notes", "")),
+            reference_case_flag=bool(row.get("reference_case_flag", False)),
+            minutes_from_prev_candidate_same_family=_as_float(row.get("minutes_from_prev_candidate_same_family")),
+            minutes_from_prev_candidate_any_family=_as_float(row.get("minutes_from_prev_candidate_any_family")),
+            candidate_rank_in_window=int(row.get("candidate_rank_in_window", 1)),
+        )
+        for row in selected
+    ]
+    return sorted(candidates, key=lambda row: (row.day, row.ts, row.direction, row.family_hint, row.reference_window_id))
+
+
+def _build_merged_rows(mechanics_rows: list[dict[str, str]], outcomes_rows: list[dict[str, str]]) -> list[dict[str, object]]:
+    outcomes_by_key = {(row.get("day", ""), row.get("ts", "")): row for row in outcomes_rows}
+    ordered_mechanics = sorted(
+        [dict(row) for row in mechanics_rows],
+        key=lambda row: (str(row.get("day", "")), _parse_ts(row.get("ts", "")) or datetime.min),
+    )
+
+    by_day: dict[str, list[dict[str, object]]] = {}
+    for row in ordered_mechanics:
+        day = str(row.get("day", ""))
+        ts = _parse_ts(row.get("ts", ""))
+        if ts is None:
+            continue
+        outcome = outcomes_by_key.get((day, row.get("ts", "")), {})
+        merged = dict(row)
+        merged.update(
+            {
+                "ts": ts,
+                "direction": _resolve_direction(outcome, row),
+                "ret_fwd_30m": _as_float(outcome.get("ret_fwd_30m")),
+                "ret_fwd_60m": _as_float(outcome.get("ret_fwd_60m")),
+                "favorable_max_30m": _as_float(outcome.get("favorable_max_30m")),
+                "adverse_max_30m": _as_float(outcome.get("adverse_max_30m")),
+            }
+        )
+        by_day.setdefault(day, []).append(merged)
+
+    enriched: list[dict[str, object]] = []
+    for day in sorted(by_day):
+        day_rows = sorted(by_day[day], key=lambda row: row["ts"])
+        closes = [_as_float(row.get("close")) for row in day_rows]
+        deltas = [_as_float(row.get("delta_1m")) for row in day_rows]
+
+        for idx, row in enumerate(day_rows):
+            row = dict(row)
+            row["cum_delta_24h"] = _rolling_sum(deltas, idx, 24 * 60)
+            row["cum_delta_180m"] = _rolling_sum(deltas, idx, 180)
+            row["cum_delta_60m"] = _rolling_sum(deltas, idx, 60)
+            row["ret_15m"] = _backward_return(closes, idx, 15)
+            row["ret_60m"] = _backward_return(closes, idx, 60)
+            enriched.append(row)
+    return sorted(enriched, key=lambda row: (str(row.get("day", "")), row["ts"]))
+
+
+def _assign_family_hint(row: dict[str, object]) -> str | None:
+    abs_delta = abs(_as_float(row.get("delta_1m")) or 0.0)
+    abs_imbalance = abs(_as_float(row.get("imbalance_1m")) or 0.0)
+    vol = _as_float(row.get("vol_1m")) or 0.0
+    dist_vwap = abs(_as_float(row.get("dist_from_vwap")) or 0.0)
+    favorable_30 = _as_float(row.get("favorable_max_30m")) or 0.0
+    adverse_30 = _as_float(row.get("adverse_max_30m")) or 0.0
+    aligned = str(row.get("delta_price_alignment_1m", "")) == "aligned"
+
+    if aligned and abs_delta >= 35.0 and (favorable_30 - adverse_30) >= 15.0 and vol >= 25.0:
+        return "F2"
+    if abs_delta >= 20.0 and abs_imbalance >= 0.45 and dist_vwap >= 15.0:
+        return "F1"
+    return None
+
+
+def _assign_chain_role(row: dict[str, object], rank_in_window_zero_based: int) -> str:
+    family = str(row.get("family_hint", ""))
+    favorable_30 = _as_float(row.get("favorable_max_30m")) or 0.0
+    adverse_30 = _as_float(row.get("adverse_max_30m")) or 0.0
+    ret_30 = _as_float(row.get("ret_fwd_30m")) or 0.0
+    aligned = str(row.get("delta_price_alignment_1m", "")) == "aligned"
+
+    if adverse_30 > favorable_30 * 1.2:
+        return "late_exhaustion"
+    if rank_in_window_zero_based == 0 and family == "F2" and aligned:
+        return "seed"
+    if rank_in_window_zero_based == 0 and family == "F1" and aligned:
+        return "release"
+    if rank_in_window_zero_based > 0 and family == "F1" and aligned and ret_30 != 0.0:
+        return "continuation"
+    return "unknown"
+
+
+def _minutes_since_prev(rows: list[dict[str, object]], idx: int, family_filter: str | None) -> float | None:
+    if idx <= 0:
+        return None
+    current_ts = rows[idx]["ts"]
+    for prev_idx in range(idx - 1, -1, -1):
+        if family_filter and str(rows[prev_idx].get("family_hint")) != family_filter:
+            continue
+        prev_ts = rows[prev_idx]["ts"]
+        return (current_ts - prev_ts).total_seconds() / 60.0
+    return None
+
+
+def _resolve_direction(outcome_row: dict[str, str], mechanics_row: dict[str, str]) -> str:
+    direction = str(outcome_row.get("reference_direction", "")).strip().lower()
+    if direction == "up":
+        return "long"
+    if direction == "down":
+        return "short"
+    delta_sign = str(mechanics_row.get("delta_sign", "")).strip().lower()
+    if delta_sign == "positive":
+        return "long"
+    if delta_sign == "negative":
+        return "short"
+    return "unknown"
+
+
+def _reference_strength_score(row: MinuteEventChainCandidateRow) -> float:
+    return (row.favorable_max_30m or 0.0) - (row.adverse_max_30m or 0.0)
+
+
+def _rolling_sum(values: list[float | None], idx: int, lookback_rows: int) -> float | None:
+    start = max(0, idx - lookback_rows + 1)
+    window = [value for value in values[start : idx + 1] if value is not None]
+    if not window:
+        return None
+    return float(sum(window))
+
+
+def _backward_return(closes: list[float | None], idx: int, lookback_rows: int) -> float | None:
+    current = closes[idx]
+    anchor_idx = idx - lookback_rows
+    if current is None or anchor_idx < 0:
+        return None
+    anchor = closes[anchor_idx]
+    if anchor is None:
+        return None
+    return current - anchor
+
+
+def _resolve_scope_dates(
+    input_root: str,
+    *,
+    date: str | None,
+    date_from: str | None,
+    date_to: str | None,
+) -> tuple[str, str]:
+    if date:
+        return date, date
+    if date_from and date_to:
+        return date_from, date_to
+    if date_from and not date_to:
+        return date_from, date_from
+
+    dates = sorted(_discover_available_dates(Path(input_root), "minute_events_mechanics") & _discover_available_dates(Path(input_root), "minute_events_outcomes"))
+    if not dates:
+        raise ValueError("no overlapping minute_events_mechanics/minute_events_outcomes datasets found")
+    return dates[0], dates[-1]
+
+
+def _discover_available_dates(input_root: Path, dataset_name: str) -> set[str]:
+    values: set[str] = set()
+    for path in sorted(input_root.glob(f"{dataset_name}_*.csv")):
+        date_part = path.stem.replace(f"{dataset_name}_", "")
+        if _is_valid_date(date_part):
+            values.add(date_part)
+    return values
+
+
+def _load_rows_for_scope(input_root: Path, dataset_name: str, date_from: str, date_to: str) -> list[dict[str, str]]:
+    start = datetime.strptime(date_from, "%Y-%m-%d").date()
+    end = datetime.strptime(date_to, "%Y-%m-%d").date()
+    if start > end:
+        raise ValueError("date_from must be <= date_to")
+
+    rows: list[dict[str, str]] = []
+    cursor = start
+    while cursor <= end:
+        date_str = cursor.strftime("%Y-%m-%d")
+        path = input_root / f"{dataset_name}_{date_str}.csv"
+        if path.exists():
+            rows.extend(_load_csv(path))
+        cursor += timedelta(days=1)
+    return rows
+
+
+def _load_csv(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def _write_dataclass_csv(rows: list[object], out_path: Path, row_type: type[object]) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    field_names = list(row_type.__dataclass_fields__.keys())
+    with out_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=field_names)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({name: _serialize_value(asdict(row).get(name)) for name in field_names})
+
+
+def _serialize_value(value: object) -> object:
+    if value is None:
+        return ""
+    return value
+
+
+def _fmt_num(value: float | None) -> str:
+    if value is None:
+        return "na"
+    return f"{value:.2f}"
+
+
+def _parse_ts(value: str) -> datetime | None:
+    text = str(value or "").strip().replace("Z", "+00:00")
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def _as_float(value: object) -> float | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def _is_valid_date(value: str) -> bool:
+    try:
+        datetime.strptime(value, "%Y-%m-%d")
+    except ValueError:
+        return False
+    return True

--- a/deltascout/delta_analyzer/types.py
+++ b/deltascout/delta_analyzer/types.py
@@ -239,6 +239,73 @@ class MinuteEventOutcomesRow:
 
 
 @dataclass(frozen=True)
+class MinuteEventChainCandidateRow:
+    ts: datetime
+    day: str
+    direction: str
+    family_hint: str
+    chain_role_hypothesis: str
+    reference_window_id: str
+    price_vs_vwap_side: str
+    cum_delta_24h: float | None
+    cum_delta_180m: float | None
+    cum_delta_60m: float | None
+    ret_15m: float | None
+    ret_60m: float | None
+    delta_1m: float | None
+    vol_1m: float | None
+    imbalance_1m: float | None
+    delta_price_alignment_1m: str
+    delta_price_efficiency_1m: float | None
+    dist_from_vwap: float | None
+    open_interest: float | None
+    funding_rate: float | None
+    liq_buy_qty: float | None
+    liq_sell_qty: float | None
+    ret_fwd_30m: float | None
+    ret_fwd_60m: float | None
+    favorable_max_30m: float | None
+    adverse_max_30m: float | None
+    notes: str
+    reference_case_flag: bool
+    minutes_from_prev_candidate_same_family: float | None
+    minutes_from_prev_candidate_any_family: float | None
+    candidate_rank_in_window: int
+
+
+@dataclass(frozen=True)
+class MinuteEventChainReferenceCaseRow:
+    ts: datetime
+    day: str
+    direction: str
+    family_hint: str
+    chain_role_label: str
+    role_confidence: str
+    phase_marker_vs_entry_candidate: str
+    reference_window_id: str
+    pre_window_summary: str
+    post_window_summary: str
+    move_followthrough_notes: str
+    invalidating_notes: str
+
+
+@dataclass(frozen=True)
+class ChainClusterSummaryRow:
+    reference_window_id: str
+    day: str
+    directional_bias: str
+    candidate_count: int
+    family_mix: str
+    earliest_ts: datetime
+    latest_ts: datetime
+    provisional_chain_pattern: str
+    contains_seed_flag: bool
+    contains_release_flag: bool
+    contains_continuation_flag: bool
+    contains_late_flag: bool
+
+
+@dataclass(frozen=True)
 class EventsBaseRow:
     ts: datetime
     event_type: str

--- a/deltascout/test/test_minute_event_process_chain_m2_6.py
+++ b/deltascout/test/test_minute_event_process_chain_m2_6.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from deltascout.delta_analyzer.modules.build_minute_event_process_chain import (
+    SUPPORTED_CHAIN_ROLES,
+    SUPPORTED_FAMILIES,
+    build_cluster_summaries,
+    build_m2_6_outputs,
+    build_reference_cases,
+)
+
+
+def _ts(day: str, hhmm: str) -> str:
+    return f"{day} {hhmm}:00"
+
+
+def _mechanics_row(
+    day: str,
+    hhmm: str,
+    *,
+    close: float,
+    delta_1m: float,
+    vol_1m: float,
+    imbalance_1m: float,
+    dist_from_vwap: float,
+    alignment: str,
+    open_interest: float = 1000.0,
+) -> dict[str, str]:
+    return {
+        "ts": _ts(day, hhmm),
+        "day": day,
+        "close": str(close),
+        "delta_1m": str(delta_1m),
+        "vol_1m": str(vol_1m),
+        "imbalance_1m": str(imbalance_1m),
+        "dist_from_vwap": str(dist_from_vwap),
+        "delta_price_alignment_1m": alignment,
+        "delta_price_efficiency_1m": "1.2",
+        "price_vs_vwap_side": "above" if dist_from_vwap > 0 else "below",
+        "open_interest": str(open_interest),
+        "funding_rate": "0.00001",
+        "liq_buy_qty": "1.0",
+        "liq_sell_qty": "0.5",
+        "delta_sign": "positive" if delta_1m > 0 else "negative" if delta_1m < 0 else "flat_or_unknown",
+    }
+
+
+def _outcomes_row(
+    day: str,
+    hhmm: str,
+    *,
+    direction: str,
+    ret_fwd_30m: float,
+    ret_fwd_60m: float,
+    favorable_30m: float,
+    adverse_30m: float,
+) -> dict[str, str]:
+    return {
+        "ts": _ts(day, hhmm),
+        "day": day,
+        "reference_direction": direction,
+        "ret_fwd_30m": str(ret_fwd_30m),
+        "ret_fwd_60m": str(ret_fwd_60m),
+        "favorable_max_30m": str(favorable_30m),
+        "adverse_max_30m": str(adverse_30m),
+    }
+
+
+def _sample_rows() -> tuple[list[dict[str, str]], list[dict[str, str]]]:
+    mechanics = [
+        _mechanics_row("2026-01-01", "00:00", close=100.0, delta_1m=10.0, vol_1m=20.0, imbalance_1m=0.2, dist_from_vwap=2.0, alignment="aligned"),
+        _mechanics_row("2026-01-01", "00:01", close=102.0, delta_1m=40.0, vol_1m=30.0, imbalance_1m=0.5, dist_from_vwap=20.0, alignment="aligned"),
+        _mechanics_row("2026-01-01", "00:05", close=104.0, delta_1m=26.0, vol_1m=29.0, imbalance_1m=0.55, dist_from_vwap=18.0, alignment="aligned"),
+        _mechanics_row("2026-01-01", "00:07", close=103.0, delta_1m=22.0, vol_1m=28.0, imbalance_1m=0.6, dist_from_vwap=16.0, alignment="aligned"),
+        _mechanics_row("2026-01-01", "00:40", close=103.0, delta_1m=21.0, vol_1m=27.0, imbalance_1m=0.5, dist_from_vwap=18.0, alignment="opposed"),
+        _mechanics_row("2026-01-02", "00:00", close=100.0, delta_1m=-38.0, vol_1m=30.0, imbalance_1m=-0.6, dist_from_vwap=-20.0, alignment="aligned"),
+    ]
+    outcomes = [
+        _outcomes_row("2026-01-01", "00:00", direction="up", ret_fwd_30m=1.0, ret_fwd_60m=2.0, favorable_30m=8.0, adverse_30m=7.0),
+        _outcomes_row("2026-01-01", "00:01", direction="up", ret_fwd_30m=30.0, ret_fwd_60m=40.0, favorable_30m=50.0, adverse_30m=20.0),
+        _outcomes_row("2026-01-01", "00:05", direction="up", ret_fwd_30m=18.0, ret_fwd_60m=22.0, favorable_30m=35.0, adverse_30m=15.0),
+        _outcomes_row("2026-01-01", "00:07", direction="up", ret_fwd_30m=-5.0, ret_fwd_60m=-10.0, favorable_30m=10.0, adverse_30m=30.0),
+        _outcomes_row("2026-01-01", "00:40", direction="up", ret_fwd_30m=5.0, ret_fwd_60m=7.0, favorable_30m=12.0, adverse_30m=11.0),
+        _outcomes_row("2026-01-02", "00:00", direction="down", ret_fwd_30m=25.0, ret_fwd_60m=35.0, favorable_30m=45.0, adverse_30m=18.0),
+    ]
+    return mechanics, outcomes
+
+
+def test_m2_6_candidates_build_from_mechanics_and_outcomes_and_schema_has_required_fields():
+    mechanics, outcomes = _sample_rows()
+    candidates, _, _ = build_m2_6_outputs(mechanics, outcomes)
+
+    assert len(candidates) >= 1
+    row = candidates[0]
+    assert hasattr(row, "ts")
+    assert hasattr(row, "day")
+    assert hasattr(row, "direction")
+    assert hasattr(row, "family_hint")
+    assert hasattr(row, "chain_role_hypothesis")
+    assert hasattr(row, "reference_window_id")
+    assert hasattr(row, "cum_delta_24h")
+    assert hasattr(row, "cum_delta_180m")
+    assert hasattr(row, "cum_delta_60m")
+    assert hasattr(row, "ret_15m")
+    assert hasattr(row, "ret_60m")
+    assert hasattr(row, "ret_fwd_30m")
+    assert hasattr(row, "ret_fwd_60m")
+    assert hasattr(row, "favorable_max_30m")
+
+
+def test_m2_6_candidates_have_supported_family_and_role_values_only():
+    mechanics, outcomes = _sample_rows()
+    candidates, _, _ = build_m2_6_outputs(mechanics, outcomes)
+
+    assert {row.family_hint for row in candidates}.issubset(SUPPORTED_FAMILIES)
+    assert {row.chain_role_hypothesis for row in candidates}.issubset(SUPPORTED_CHAIN_ROLES)
+
+
+def test_m2_6_reference_window_id_and_row_ordering_are_deterministic():
+    mechanics, outcomes = _sample_rows()
+    first, _, _ = build_m2_6_outputs(mechanics, outcomes)
+    second, _, _ = build_m2_6_outputs(mechanics, outcomes)
+
+    assert [row.reference_window_id for row in first] == [row.reference_window_id for row in second]
+    assert [row.ts for row in first] == sorted([row.ts for row in first])
+
+
+def test_m2_6_empty_no_match_case_is_clean():
+    mechanics = [
+        _mechanics_row("2026-01-01", "00:00", close=100.0, delta_1m=1.0, vol_1m=1.0, imbalance_1m=0.1, dist_from_vwap=1.0, alignment="opposed"),
+    ]
+    outcomes = [
+        _outcomes_row("2026-01-01", "00:00", direction="up", ret_fwd_30m=0.0, ret_fwd_60m=0.0, favorable_30m=1.0, adverse_30m=1.0),
+    ]
+
+    candidates, references, clusters = build_m2_6_outputs(mechanics, outcomes)
+    assert candidates == []
+    assert references == []
+    assert clusters == []
+
+
+def test_m2_6_reference_cases_are_deterministic_and_keep_representative_rows_when_eligible():
+    mechanics, outcomes = _sample_rows()
+    candidates, _, _ = build_m2_6_outputs(mechanics, outcomes)
+
+    a = build_reference_cases(candidates)
+    b = build_reference_cases(candidates)
+
+    assert a == b
+    assert len(a) >= 1
+    required = {
+        "ts",
+        "day",
+        "direction",
+        "family_hint",
+        "chain_role_label",
+        "role_confidence",
+        "phase_marker_vs_entry_candidate",
+        "reference_window_id",
+        "pre_window_summary",
+        "post_window_summary",
+        "move_followthrough_notes",
+        "invalidating_notes",
+    }
+    assert required.issubset(set(a[0].__dataclass_fields__.keys()))
+
+
+def test_m2_6_cluster_summaries_deterministic_and_support_lone_and_multi_window_patterns():
+    mechanics, outcomes = _sample_rows()
+    candidates, _, _ = build_m2_6_outputs(mechanics, outcomes)
+
+    first = build_cluster_summaries(candidates)
+    second = build_cluster_summaries(candidates)
+
+    assert first == second
+    assert any(row.candidate_count == 1 for row in first)
+    assert any(row.candidate_count > 1 for row in first)
+    assert all(row.provisional_chain_pattern in {"seed_only", "seed_then_release", "release_only", "continuation_cluster", "late_mixed", "ambiguous"} for row in first)
+
+
+def test_m2_6_reference_window_id_grouping_is_day_and_direction_aware():
+    mechanics, outcomes = _sample_rows()
+    candidates, _, _ = build_m2_6_outputs(mechanics, outcomes)
+
+    grouped = {(row.day, row.direction, row.reference_window_id) for row in candidates}
+    assert len(grouped) >= 2
+    assert all(window_id.startswith(f"{day}_{direction}_") for day, direction, window_id in grouped)
+
+
+def test_m2_6_role_values_include_unknown_when_evidence_is_insufficient():
+    mechanics = [
+        _mechanics_row("2026-01-03", "00:00", close=100.0, delta_1m=22.0, vol_1m=28.0, imbalance_1m=0.5, dist_from_vwap=16.0, alignment="opposed"),
+    ]
+    outcomes = [
+        _outcomes_row("2026-01-03", "00:00", direction="up", ret_fwd_30m=1.0, ret_fwd_60m=1.0, favorable_30m=9.0, adverse_30m=8.0),
+    ]
+
+    candidates, _, _ = build_m2_6_outputs(mechanics, outcomes)
+    assert len(candidates) == 1
+    assert candidates[0].chain_role_hypothesis == "unknown"
+
+
+def test_m2_6_candidate_helper_fields_are_present_when_multiple_candidates_exist():
+    mechanics, outcomes = _sample_rows()
+    candidates, _, _ = build_m2_6_outputs(mechanics, outcomes)
+
+    assert any(row.minutes_from_prev_candidate_any_family is not None for row in candidates)
+    assert all(row.candidate_rank_in_window >= 1 for row in candidates)
+
+
+def test_m2_6_cluster_summary_fields_exist_and_have_datetime_bounds():
+    mechanics, outcomes = _sample_rows()
+    candidates, _, clusters = build_m2_6_outputs(mechanics, outcomes)
+
+    assert clusters
+    sample = clusters[0]
+    assert isinstance(sample.earliest_ts, datetime)
+    assert isinstance(sample.latest_ts, datetime)
+    assert sample.earliest_ts <= sample.latest_ts
+
+
+def test_m2_6_candidate_build_is_deterministic_under_input_permutation():
+    mechanics, outcomes = _sample_rows()
+    forward, _, _ = build_m2_6_outputs(mechanics, outcomes)
+    reverse, _, _ = build_m2_6_outputs(list(reversed(mechanics)), list(reversed(outcomes)))
+
+    assert forward == reverse
+
+
+def test_m2_6_reference_cases_include_low_confidence_when_role_is_ambiguous():
+    mechanics = [
+        _mechanics_row("2026-01-04", "00:00", close=100.0, delta_1m=24.0, vol_1m=27.0, imbalance_1m=0.5, dist_from_vwap=17.0, alignment="opposed"),
+    ]
+    outcomes = [
+        _outcomes_row("2026-01-04", "00:00", direction="up", ret_fwd_30m=1.0, ret_fwd_60m=1.0, favorable_30m=9.0, adverse_30m=8.0),
+    ]
+    candidates, references, _ = build_m2_6_outputs(mechanics, outcomes)
+
+    assert candidates[0].chain_role_hypothesis == "unknown"
+    assert references[0].role_confidence == "low"
+
+
+def test_m2_6_cluster_pattern_is_conservative_for_mixed_roles():
+    mechanics, outcomes = _sample_rows()
+    candidates, _, clusters = build_m2_6_outputs(mechanics, outcomes)
+    mixed_windows = [row for row in clusters if row.candidate_count > 1]
+
+    assert mixed_windows
+    assert all(row.provisional_chain_pattern in {"seed_then_release", "late_mixed", "ambiguous", "continuation_cluster"} for row in mixed_windows)


### PR DESCRIPTION
### Motivation
- Provide a research-only, minute-first bridge (M2.6) that moves minute-event rows toward process-chain candidate review without relying on PEAK/review tables. 
- Materialize the three operational M2.6 outputs required for research workflows: candidate extraction, deterministic local-window grouping, and lightweight cluster summaries. 
- Keep all logic explicit, auditable, conservative in confidence, and deterministic for reproducible research builds. 

### Description
- Add a new builder module `deltascout/delta_analyzer/modules/build_minute_event_process_chain.py` that reads `minute_events_mechanics` + `minute_events_outcomes`, merges them, extracts candidates for `F1`/`F2` families, assigns provisional `chain_role_hypothesis`, deterministically assigns `reference_window_id`, and materializes the three outputs. 
- Add dataclass contracts for the outputs in `deltascout/delta_analyzer/types.py`: `MinuteEventChainCandidateRow`, `MinuteEventChainReferenceCaseRow`, and `ChainClusterSummaryRow`. 
- Add CLI support in `deltascout/delta_analyzer/cli.py` via `--build-m2-6` with `--date` / `--date-from` / `--date-to`, and deterministic output paths under an `m2_6` subdirectory. 
- Add focused unit tests in `deltascout/test/test_minute_event_process_chain_m2_6.py` covering schema, deterministic ordering, family/role constraints, empty behavior, window grouping, reference-case selection, cluster summaries, and permutation determinism. 
- Provide minimal README updates in `deltascout/delta_analyzer/README.md` documenting the M2.6 scope and CLI usage. 

### Testing
- Ran the focused M2.6 unit tests with `pytest -q deltascout/test/test_minute_event_process_chain_m2_6.py` and all tests passed (`13 passed`). 
- Ran related phase tests with `pytest -q deltascout/test/test_minute_events_mechanics.py deltascout/test/test_minute_events_outcomes.py` and they passed (`23 passed`). 
- Performed an end-to-end build exercise with the CLI producing CSV outputs using `python -m deltascout.delta_analyzer.cli --build-m2-6 --date-from 2026-04-04 --date-to 2026-04-05 --input-root deltascout/research_material/minute_datasets --output-root /tmp/btc_m2_6_demo`, which wrote the three outputs to `/tmp/btc_m2_6_demo/m2_6/` successfully and contained non-empty rows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3cfe0b5b08323b5f8ddabd841813e)